### PR TITLE
Implement recipe types and recipe probes

### DIFF
--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -24,7 +24,14 @@ class RecipesScreen extends StatelessWidget {
                             : const Icon(Icons.rotate_left_rounded),
                         onTap: () => Navigator.pushNamed(
                             context, PageRouter.recipe,
-                            arguments: index)));
+                            arguments: index),
+                        onLongPress: () => {
+                              showDialog<String>(
+                                  context: context,
+                                  builder: (BuildContext context) =>
+                                      DeleteRecipe(
+                                          recipe: state.recipes[index]))
+                            }));
               }),
           floatingActionButton: Column(
               mainAxisAlignment: MainAxisAlignment.end,
@@ -35,10 +42,8 @@ class RecipesScreen extends StatelessWidget {
                     label: const Text("Standard Recipe"),
                     icon: const Icon(Icons.add),
                     onPressed: () => {
-                          context.read<RecipeBloc>().add(RecipeAdded(
-                              recipeType: "Standard Recipe",
-                              recipeNumber:
-                                  (state.recipes.length + 1).toString())),
+                          context.read<RecipeBloc>().add(
+                              const RecipeAdded(recipeType: "Standard Recipe")),
                           Navigator.pushNamed(context, PageRouter.recipe,
                               arguments: state.recipes.length),
                         }),
@@ -50,14 +55,42 @@ class RecipesScreen extends StatelessWidget {
                     label: const Text("Non-standard Recipe"),
                     icon: const Icon(Icons.add),
                     onPressed: () => {
-                          context.read<RecipeBloc>().add(RecipeAdded(
-                              recipeType: "Non-standard Recipe",
-                              recipeNumber:
-                                  (state.recipes.length + 1).toString())),
+                          context.read<RecipeBloc>().add(const RecipeAdded(
+                              recipeType: "Non-standard Recipe")),
                           Navigator.pushNamed(context, PageRouter.recipe,
                               arguments: state.recipes.length),
                         })
               ]));
+    });
+  }
+}
+
+class DeleteRecipe extends StatelessWidget {
+  final Recipe recipe;
+
+  const DeleteRecipe({Key? key, required this.recipe}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    String recipeName = recipe.recipeName.value;
+    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
+      return AlertDialog(
+        title: const Text('Delete recipe'),
+        content: Text('Would you like to delete the $recipeName recipe?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'Cancel'),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => {
+              context.read<RecipeBloc>().add(RecipeDeleted(recipe: recipe)),
+              Navigator.pop(context, 'OK')
+            },
+            child: const Text('OK'),
+          ),
+        ],
+      );
     });
   }
 }

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -38,8 +38,7 @@ class RecipesScreen extends StatelessWidget {
                           context.read<RecipeBloc>().add(RecipeAdded(
                               recipeType: "Standard Recipe",
                               recipeNumber:
-                                  (state.recipes.length + 1).toString(),
-                              standard: true)),
+                                  (state.recipes.length + 1).toString())),
                           Navigator.pushNamed(context, PageRouter.recipe,
                               arguments: state.recipes.length),
                         }),
@@ -48,14 +47,13 @@ class RecipesScreen extends StatelessWidget {
                 ),
                 FloatingActionButton.extended(
                     heroTag: null,
-                    label: const Text("Modified Recipe"),
+                    label: const Text("Non-standard Recipe"),
                     icon: const Icon(Icons.add),
                     onPressed: () => {
                           context.read<RecipeBloc>().add(RecipeAdded(
-                              recipeType: "Modified Recipe",
+                              recipeType: "Non-standard Recipe",
                               recipeNumber:
-                                  (state.recipes.length + 1).toString(),
-                              standard: false)),
+                                  (state.recipes.length + 1).toString())),
                           Navigator.pushNamed(context, PageRouter.recipe,
                               arguments: state.recipes.length),
                         })

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -18,7 +18,7 @@ class RecipesScreen extends StatelessWidget {
                 return Card(
                     child: ListTile(
                         title: Text(state.recipes[index].recipeName.value),
-                        subtitle: Text(state.recipes[index].recipeVolume.value),
+                        subtitle: Text(state.recipes[index].recipeType),
                         trailing: state.recipes[index].saved
                             ? const Icon(Icons.done)
                             : const Icon(Icons.rotate_left_rounded),
@@ -30,10 +30,32 @@ class RecipesScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.end,
               children: <Widget>[
-                FloatingActionButton(
-                    child: const Icon(Icons.add),
+                FloatingActionButton.extended(
+                    heroTag: null,
+                    label: const Text("Standard Recipe"),
+                    icon: const Icon(Icons.add),
                     onPressed: () => {
-                          context.read<RecipeBloc>().add(RecipeAdded()),
+                          context.read<RecipeBloc>().add(RecipeAdded(
+                              recipeType: "Standard Recipe",
+                              recipeNumber:
+                                  (state.recipes.length + 1).toString(),
+                              standard: true)),
+                          Navigator.pushNamed(context, PageRouter.recipe,
+                              arguments: state.recipes.length),
+                        }),
+                const SizedBox(
+                  height: 10,
+                ),
+                FloatingActionButton.extended(
+                    heroTag: null,
+                    label: const Text("Modified Recipe"),
+                    icon: const Icon(Icons.add),
+                    onPressed: () => {
+                          context.read<RecipeBloc>().add(RecipeAdded(
+                              recipeType: "Modified Recipe",
+                              recipeNumber:
+                                  (state.recipes.length + 1).toString(),
+                              standard: false)),
                           Navigator.pushNamed(context, PageRouter.recipe,
                               arguments: state.recipes.length),
                         })

--- a/lib/navigation/models/page_router.dart
+++ b/lib/navigation/models/page_router.dart
@@ -8,6 +8,7 @@ class PageRouter {
   static const home = '/';
   static const collection = '/collection';
   static const recipe = '/recipe';
+  static const recipeProbe = '/recipeprobe';
   static const ingredient = '/ingredient';
   static const sensitizationHelp = '/sensitizationhelp';
   static const firstPassHelp = '/firstpasshelp';
@@ -23,6 +24,9 @@ class PageRouter {
       case recipe:
         var recipeIndex = routeSettings.arguments as int;
         return _buildRoute(RecipePage(recipeIndex));
+      case recipeProbe:
+        var recipeIndex = routeSettings.arguments as int;
+        return _buildRoute(RecipeProbePage(recipeIndex));
       case ingredient:
         var indices = routeSettings.arguments as List; // TODO: Use a hash-map
         int recipeIndex = indices[0];

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -28,13 +28,9 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
   }
 
   void _onRecipeAdded(RecipeAdded event, Emitter<RecipeState> emit) {
-    final newRecipe = Recipe();
-    final recipeType = event.recipeType;
-    bool standard = event.standard;
-    Recipe recipe = newRecipe.copyWith(
+    final recipe = Recipe(
         recipeNumber: RecipeNumber.dirty(event.recipeNumber),
-        recipeType: recipeType,
-        standard: standard);
+        recipeType: event.recipeType);
 
     List<Recipe> recipes = List.from(state.recipes);
     recipes.add(recipe);
@@ -94,8 +90,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
-    Recipe recipe = recipes[changedRecipeIndex]
-        .copyWith(saved: event.recipeSaved, standard: false);
+    Recipe recipe =
+        recipes[changedRecipeIndex].copyWith(saved: event.recipeSaved);
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -118,20 +114,20 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
         List.from(recipes[changedRecipeIndex].ingredients);
     ingredients.add(ingredient);
 
-    Recipe recipe = (event.recipe.standard == false &&
+    Recipe recipe = (event.recipe.saved == true &&
             event.recipe.recipeType == "Standard Recipe")
         ? recipes[changedRecipeIndex].copyWith(
             ingredients: ingredients,
             saved: false,
             recipeType: "Modified Recipe",
             recipeNumber: RecipeNumber.dirty((state.recipes.length + 1)
-                .toString())) // TODO: Handle recipeNumber better
+                .toString())) // TODO: Handle recipeNumber better + handle UUID?
         : recipes[changedRecipeIndex]
             .copyWith(ingredients: ingredients, saved: false);
 
     recipes.removeAt(changedRecipeIndex);
 
-    if (event.recipe.standard == false &&
+    if (event.recipe.saved == true &&
         event.recipe.recipeType == "Standard Recipe") {
       recipes.insert(changedRecipeIndex, standardRecipe);
     }

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -11,6 +11,7 @@ part 'recipe_state.dart';
 class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
   RecipeBloc() : super(const RecipeState()) {
     on<RecipeAdded>(_onRecipeAdded);
+    on<RecipeDeleted>(_onRecipeDeleted);
     on<RecipeNameChanged>(_recipeNameChanged);
     on<RecipeVolumeChanged>(_recipeVolumeChanged);
     on<RecipeStatusChanged>(_onRecipeStatusChanged);
@@ -33,6 +34,16 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     List<Recipe> recipes = List.from(state.recipes);
     recipes.add(recipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onRecipeDeleted(RecipeDeleted event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    recipes.removeAt(changedRecipeIndex);
 
     emit(state.copyWith(recipes: recipes));
   }

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -147,7 +147,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
@@ -170,7 +171,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
@@ -193,7 +195,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex].copyWith(
@@ -217,7 +220,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex].copyWith(
@@ -240,7 +244,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex].copyWith(
@@ -264,7 +269,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex].copyWith(
@@ -287,7 +293,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex].copyWith(
@@ -311,7 +318,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
@@ -334,7 +342,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
-    List<Ingredient> ingredients = recipes[changedRecipeIndex].ingredients;
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:gibsonify/recipe/models/models.dart';
 import 'package:gibsonify/recipe/recipe.dart';
@@ -11,7 +12,6 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
   RecipeBloc() : super(const RecipeState()) {
     on<RecipeAdded>(_onRecipeAdded);
     on<RecipeNameChanged>(_recipeNameChanged);
-    on<RecipeNumberChanged>(_recipeNumberChanged);
     on<RecipeVolumeChanged>(_recipeVolumeChanged);
     on<RecipeStatusChanged>(_onRecipeStatusChanged);
     on<IngredientAdded>(_onIngredientAdded);
@@ -28,9 +28,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
   }
 
   void _onRecipeAdded(RecipeAdded event, Emitter<RecipeState> emit) {
-    final recipe = Recipe(
-        recipeNumber: RecipeNumber.dirty(event.recipeNumber),
-        recipeType: event.recipeType);
+    final recipe = Recipe(recipeType: event.recipeType);
 
     List<Recipe> recipes = List.from(state.recipes);
     recipes.add(recipe);
@@ -45,23 +43,6 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     Recipe recipe = recipes[changedRecipeIndex]
         .copyWith(recipeName: RecipeName.dirty(event.recipeName), saved: false);
-
-    recipes.removeAt(changedRecipeIndex);
-    recipes.insert(changedRecipeIndex, recipe);
-
-    emit(state.copyWith(recipes: recipes));
-  }
-
-  void _recipeNumberChanged(
-      // TODO: Remove?
-      RecipeNumberChanged event,
-      Emitter<RecipeState> emit) {
-    List<Recipe> recipes = List.from(state.recipes);
-
-    int changedRecipeIndex = recipes.indexOf(event.recipe);
-
-    Recipe recipe = recipes[changedRecipeIndex]
-        .copyWith(recipeNumber: RecipeNumber.dirty(event.recipeNumber));
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -100,11 +81,6 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
   }
 
   void _onIngredientAdded(IngredientAdded event, Emitter<RecipeState> emit) {
-    // if standard is false:
-    // make a copy of the current recipe and add it to the list
-    // then continue to edit this current recipe, getting a new recipe number
-    // and making recipeType = Modified Recipe
-
     List<Recipe> recipes = List.from(state.recipes);
     Recipe standardRecipe = event.recipe;
     int changedRecipeIndex = recipes.indexOf(event.recipe);
@@ -120,8 +96,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
             ingredients: ingredients,
             saved: false,
             recipeType: "Modified Recipe",
-            recipeNumber: RecipeNumber.dirty((state.recipes.length + 1)
-                .toString())) // TODO: Handle recipeNumber better + handle UUID?
+            recipeNumber: const Uuid().v4())
         : recipes[changedRecipeIndex]
             .copyWith(ingredients: ingredients, saved: false);
 

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -99,8 +99,9 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
-    const probe = '';
-    List<String> probes = List.from(recipes[changedRecipeIndex].probes);
+    Map<String, dynamic> probe = {'probe': '', 'key': const Uuid().v4()};
+    List<Map<String, dynamic>> probes =
+        List.from(recipes[changedRecipeIndex].probes);
     probes.add(probe);
 
     Recipe recipe =
@@ -116,10 +117,15 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
-    List<String> probes = List.from(recipes[changedRecipeIndex].probes);
+    List<Map<String, dynamic>> probes =
+        List.from(recipes[changedRecipeIndex].probes);
     int changedProbeIndex = event.probeIndex;
 
-    String probe = event.probe;
+    String probeName = event.probeName;
+    Map<String, dynamic> probe = {
+      'probe': probeName,
+      'key': probes[changedProbeIndex]['key']
+    };
 
     probes.removeAt(changedProbeIndex);
     probes.insert(changedProbeIndex, probe);
@@ -137,7 +143,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Recipe> recipes = List.from(state.recipes);
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
-    List<String> probes = List.from(recipes[changedRecipeIndex].probes);
+    List<Map<String, dynamic>> probes =
+        List.from(recipes[changedRecipeIndex].probes);
     int changedProbeIndex = probes.indexOf(event.probe);
     probes.removeAt(changedProbeIndex);
 

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -15,6 +15,9 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     on<RecipeNameChanged>(_recipeNameChanged);
     on<RecipeVolumeChanged>(_recipeVolumeChanged);
     on<RecipeStatusChanged>(_onRecipeStatusChanged);
+    on<ProbeAdded>(_onProbeAdded);
+    on<ProbeChanged>(_onProbeChanged);
+    on<ProbeDeleted>(_onProbeDeleted);
     on<IngredientAdded>(_onIngredientAdded);
     on<IngredientDeleted>(_onIngredientDeleted);
     on<IngredientStatusChanged>(_onIngredientStatusChanged);
@@ -89,6 +92,61 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
 
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onProbeAdded(ProbeAdded event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    const probe = '';
+    List<String> probes = List.from(recipes[changedRecipeIndex].probes);
+    probes.add(probe);
+
+    Recipe recipe =
+        recipes[changedRecipeIndex].copyWith(probes: probes, saved: false);
+
+    recipes.removeAt(changedRecipeIndex);
+
+    recipes.insert(changedRecipeIndex, recipe);
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onProbeChanged(ProbeChanged event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    List<String> probes = List.from(recipes[changedRecipeIndex].probes);
+    int changedProbeIndex = event.probeIndex;
+
+    String probe = event.probe;
+
+    probes.removeAt(changedProbeIndex);
+    probes.insert(changedProbeIndex, probe);
+
+    Recipe recipe =
+        recipes[changedRecipeIndex].copyWith(probes: probes, saved: false);
+
+    recipes.removeAt(changedRecipeIndex);
+    recipes.insert(changedRecipeIndex, recipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onProbeDeleted(ProbeDeleted event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    List<String> probes = List.from(recipes[changedRecipeIndex].probes);
+    int changedProbeIndex = probes.indexOf(event.probe);
+    probes.removeAt(changedProbeIndex);
+
+    Recipe recipe =
+        recipes[changedRecipeIndex].copyWith(probes: probes, saved: false);
+
+    recipes.removeAt(changedRecipeIndex);
+
+    recipes.insert(changedRecipeIndex, recipe);
     emit(state.copyWith(recipes: recipes));
   }
 

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -15,6 +15,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     on<RecipeVolumeChanged>(_recipeVolumeChanged);
     on<RecipeStatusChanged>(_onRecipeStatusChanged);
     on<IngredientAdded>(_onIngredientAdded);
+    on<IngredientDeleted>(_onIngredientDeleted);
     on<IngredientStatusChanged>(_onIngredientStatusChanged);
     on<IngredientNameChanged>(_onIngredientNameChanged);
     on<IngredientDescriptionChanged>(_onIngredientDescriptionChanged);
@@ -89,6 +90,37 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Ingredient> ingredients =
         List.from(recipes[changedRecipeIndex].ingredients);
     ingredients.add(ingredient);
+
+    Recipe recipe = (event.recipe.saved == true &&
+            event.recipe.recipeType == "Standard Recipe")
+        ? recipes[changedRecipeIndex].copyWith(
+            ingredients: ingredients,
+            saved: false,
+            recipeType: "Modified Recipe",
+            recipeNumber: const Uuid().v4())
+        : recipes[changedRecipeIndex]
+            .copyWith(ingredients: ingredients, saved: false);
+
+    recipes.removeAt(changedRecipeIndex);
+
+    if (event.recipe.saved == true &&
+        event.recipe.recipeType == "Standard Recipe") {
+      recipes.insert(changedRecipeIndex, standardRecipe);
+    }
+    recipes.insert(changedRecipeIndex, recipe);
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onIngredientDeleted(
+      IngredientDeleted event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+    Recipe standardRecipe = event.recipe;
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
+    int changedIngredientIndex = ingredients.indexOf(event.ingredient);
+    ingredients.removeAt(changedIngredientIndex);
 
     Recipe recipe = (event.recipe.saved == true &&
             event.recipe.recipeType == "Standard Recipe")

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -56,6 +56,16 @@ class IngredientAdded extends RecipeEvent {
   List<Object> get props => [recipe];
 }
 
+class IngredientDeleted extends RecipeEvent {
+  final Recipe recipe;
+  final Ingredient ingredient;
+
+  const IngredientDeleted({required this.recipe, required this.ingredient});
+
+  @override
+  List<Object> get props => [recipe, ingredient];
+}
+
 class IngredientStatusChanged extends RecipeEvent {
   final bool ingredientSaved;
   final Ingredient ingredient;

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -10,15 +10,11 @@ abstract class RecipeEvent extends Equatable {
 class RecipeAdded extends RecipeEvent {
   final String recipeType;
   final String recipeNumber;
-  final bool standard;
 
-  const RecipeAdded(
-      {required this.recipeType,
-      required this.recipeNumber,
-      required this.standard});
+  const RecipeAdded({required this.recipeType, required this.recipeNumber});
 
   @override
-  List<Object> get props => [recipeType, recipeNumber, standard];
+  List<Object> get props => [recipeType, recipeNumber];
 }
 
 class RecipeNameChanged extends RecipeEvent {

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -55,6 +55,37 @@ class RecipeStatusChanged extends RecipeEvent {
   List<Object> get props => [recipeSaved, recipe];
 }
 
+class ProbeAdded extends RecipeEvent {
+  final Recipe recipe;
+
+  const ProbeAdded({required this.recipe});
+
+  @override
+  List<Object> get props => [recipe];
+}
+
+class ProbeChanged extends RecipeEvent {
+  final Recipe recipe;
+  final String probe;
+  final int probeIndex;
+
+  const ProbeChanged(
+      {required this.recipe, required this.probe, required this.probeIndex});
+
+  @override
+  List<Object> get props => [recipe, probe, probeIndex];
+}
+
+class ProbeDeleted extends RecipeEvent {
+  final Recipe recipe;
+  final String probe;
+
+  const ProbeDeleted({required this.recipe, required this.probe});
+
+  @override
+  List<Object> get props => [recipe, probe];
+}
+
 class IngredientAdded extends RecipeEvent {
   final Recipe recipe;
 

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -9,12 +9,20 @@ abstract class RecipeEvent extends Equatable {
 
 class RecipeAdded extends RecipeEvent {
   final String recipeType;
-  final String recipeNumber;
 
-  const RecipeAdded({required this.recipeType, required this.recipeNumber});
+  const RecipeAdded({required this.recipeType});
 
   @override
-  List<Object> get props => [recipeType, recipeNumber];
+  List<Object> get props => [recipeType];
+}
+
+class RecipeDeleted extends RecipeEvent {
+  final Recipe recipe;
+
+  const RecipeDeleted({required this.recipe});
+
+  @override
+  List<Object> get props => [recipe];
 }
 
 class RecipeNameChanged extends RecipeEvent {

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -66,19 +66,21 @@ class ProbeAdded extends RecipeEvent {
 
 class ProbeChanged extends RecipeEvent {
   final Recipe recipe;
-  final String probe;
+  final String probeName;
   final int probeIndex;
 
   const ProbeChanged(
-      {required this.recipe, required this.probe, required this.probeIndex});
+      {required this.recipe,
+      required this.probeName,
+      required this.probeIndex});
 
   @override
-  List<Object> get props => [recipe, probe, probeIndex];
+  List<Object> get props => [recipe, probeName, probeIndex];
 }
 
 class ProbeDeleted extends RecipeEvent {
   final Recipe recipe;
-  final String probe;
+  final Map<String, dynamic> probe;
 
   const ProbeDeleted({required this.recipe, required this.probe});
 

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -27,16 +27,6 @@ class RecipeNameChanged extends RecipeEvent {
   List<Object> get props => [recipeName, recipe];
 }
 
-class RecipeNumberChanged extends RecipeEvent {
-  final String recipeNumber;
-  final Recipe recipe;
-
-  const RecipeNumberChanged({required this.recipeNumber, required this.recipe});
-
-  @override
-  List<Object> get props => [recipeNumber, recipe];
-}
-
 class RecipeVolumeChanged extends RecipeEvent {
   final String recipeVolume;
   final Recipe recipe;

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -7,7 +7,19 @@ abstract class RecipeEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class RecipeAdded extends RecipeEvent {}
+class RecipeAdded extends RecipeEvent {
+  final String recipeType;
+  final String recipeNumber;
+  final bool standard;
+
+  const RecipeAdded(
+      {required this.recipeType,
+      required this.recipeNumber,
+      required this.standard});
+
+  @override
+  List<Object> get props => [recipeType, recipeNumber, standard];
+}
 
 class RecipeNameChanged extends RecipeEvent {
   final String recipeName;

--- a/lib/recipe/models/recipe_item.dart
+++ b/lib/recipe/models/recipe_item.dart
@@ -10,7 +10,7 @@ class Recipe extends Equatable {
     this.recipeType = "",
     this.recipeVolume = const RecipeVolume.pure(),
     this.ingredients = const <Ingredient>[],
-    this.probes = const <String>[],
+    this.probes = const <Map<String, dynamic>>[],
     this.saved = false,
   }) : recipeNumber = recipeNumber ?? const Uuid().v4();
 
@@ -19,7 +19,7 @@ class Recipe extends Equatable {
   final String recipeType;
   final RecipeVolume recipeVolume;
   final List<Ingredient> ingredients;
-  final List<String> probes;
+  final List<Map<String, dynamic>> probes;
   final bool saved;
 
   Recipe copyWith({
@@ -28,7 +28,7 @@ class Recipe extends Equatable {
     String? recipeType,
     RecipeVolume? recipeVolume,
     List<Ingredient>? ingredients,
-    List<String>? probes,
+    List<Map<String, dynamic>>? probes,
     bool? saved,
   }) {
     return Recipe(

--- a/lib/recipe/models/recipe_item.dart
+++ b/lib/recipe/models/recipe_item.dart
@@ -7,38 +7,54 @@ class Recipe extends Equatable {
   Recipe(
       {this.recipeName = const RecipeName.pure(),
       this.recipeNumber = const RecipeNumber.pure(),
+      this.recipeType = "",
       this.recipeVolume = const RecipeVolume.pure(),
       this.ingredients = const <Ingredient>[],
+      this.standard = true,
       this.saved = false,
       String? id})
       : id = id ?? const Uuid().v4();
 
   final RecipeName recipeName;
   final RecipeNumber recipeNumber;
+  final String recipeType;
   final RecipeVolume recipeVolume;
   final List<Ingredient> ingredients;
+  final bool standard;
   final bool saved;
   final String id;
 
   Recipe copyWith(
       {RecipeName? recipeName,
       RecipeNumber? recipeNumber,
+      String? recipeType,
       RecipeVolume? recipeVolume,
       List<Ingredient>? ingredients,
+      bool? standard,
       bool? saved,
       String? id}) {
     return Recipe(
         recipeName: recipeName ?? this.recipeName,
         recipeNumber: recipeNumber ?? this.recipeNumber,
+        recipeType: recipeType ?? this.recipeType,
         recipeVolume: recipeVolume ?? this.recipeVolume,
         ingredients: ingredients ?? this.ingredients,
+        standard: standard ?? this.standard,
         saved: saved ?? this.saved,
         id: id ?? this.id);
   }
 
   @override
-  List<Object> get props =>
-      [recipeName, recipeNumber, recipeVolume, ingredients, saved, id];
+  List<Object> get props => [
+        recipeName,
+        recipeNumber,
+        recipeType,
+        recipeVolume,
+        ingredients,
+        standard,
+        saved,
+        id
+      ];
 }
 
 enum RecipeNameValidationError { invalid }

--- a/lib/recipe/models/recipe_item.dart
+++ b/lib/recipe/models/recipe_item.dart
@@ -10,7 +10,6 @@ class Recipe extends Equatable {
       this.recipeType = "",
       this.recipeVolume = const RecipeVolume.pure(),
       this.ingredients = const <Ingredient>[],
-      this.standard = true,
       this.saved = false,
       String? id})
       : id = id ?? const Uuid().v4();
@@ -20,7 +19,6 @@ class Recipe extends Equatable {
   final String recipeType;
   final RecipeVolume recipeVolume;
   final List<Ingredient> ingredients;
-  final bool standard;
   final bool saved;
   final String id;
 
@@ -30,7 +28,6 @@ class Recipe extends Equatable {
       String? recipeType,
       RecipeVolume? recipeVolume,
       List<Ingredient>? ingredients,
-      bool? standard,
       bool? saved,
       String? id}) {
     return Recipe(
@@ -39,7 +36,6 @@ class Recipe extends Equatable {
         recipeType: recipeType ?? this.recipeType,
         recipeVolume: recipeVolume ?? this.recipeVolume,
         ingredients: ingredients ?? this.ingredients,
-        standard: standard ?? this.standard,
         saved: saved ?? this.saved,
         id: id ?? this.id);
   }
@@ -51,7 +47,6 @@ class Recipe extends Equatable {
         recipeType,
         recipeVolume,
         ingredients,
-        standard,
         saved,
         id
       ];

--- a/lib/recipe/models/recipe_item.dart
+++ b/lib/recipe/models/recipe_item.dart
@@ -4,40 +4,38 @@ import 'package:gibsonify/recipe/models/recipe_ingredient.dart';
 import 'package:uuid/uuid.dart';
 
 class Recipe extends Equatable {
-  Recipe(
-      {this.recipeName = const RecipeName.pure(),
-      this.recipeNumber = const RecipeNumber.pure(),
-      this.recipeType = "",
-      this.recipeVolume = const RecipeVolume.pure(),
-      this.ingredients = const <Ingredient>[],
-      this.saved = false,
-      String? id})
-      : id = id ?? const Uuid().v4();
+  Recipe({
+    this.recipeName = const RecipeName.pure(),
+    String? recipeNumber,
+    this.recipeType = "",
+    this.recipeVolume = const RecipeVolume.pure(),
+    this.ingredients = const <Ingredient>[],
+    this.saved = false,
+  }) : recipeNumber = recipeNumber ?? const Uuid().v4();
 
   final RecipeName recipeName;
-  final RecipeNumber recipeNumber;
+  final String recipeNumber;
   final String recipeType;
   final RecipeVolume recipeVolume;
   final List<Ingredient> ingredients;
   final bool saved;
-  final String id;
 
-  Recipe copyWith(
-      {RecipeName? recipeName,
-      RecipeNumber? recipeNumber,
-      String? recipeType,
-      RecipeVolume? recipeVolume,
-      List<Ingredient>? ingredients,
-      bool? saved,
-      String? id}) {
+  Recipe copyWith({
+    RecipeName? recipeName,
+    String? recipeNumber,
+    String? recipeType,
+    RecipeVolume? recipeVolume,
+    List<Ingredient>? ingredients,
+    bool? saved,
+  }) {
     return Recipe(
-        recipeName: recipeName ?? this.recipeName,
-        recipeNumber: recipeNumber ?? this.recipeNumber,
-        recipeType: recipeType ?? this.recipeType,
-        recipeVolume: recipeVolume ?? this.recipeVolume,
-        ingredients: ingredients ?? this.ingredients,
-        saved: saved ?? this.saved,
-        id: id ?? this.id);
+      recipeName: recipeName ?? this.recipeName,
+      recipeNumber: recipeNumber ?? this.recipeNumber,
+      recipeType: recipeType ?? this.recipeType,
+      recipeVolume: recipeVolume ?? this.recipeVolume,
+      ingredients: ingredients ?? this.ingredients,
+      saved: saved ?? this.saved,
+    );
   }
 
   @override
@@ -48,7 +46,6 @@ class Recipe extends Equatable {
         recipeVolume,
         ingredients,
         saved,
-        id
       ];
 }
 
@@ -61,20 +58,6 @@ class RecipeName extends FormzInput<String, RecipeNameValidationError> {
   @override
   RecipeNameValidationError? validator(String? value) {
     return value?.isNotEmpty == true ? null : RecipeNameValidationError.invalid;
-  }
-}
-
-enum RecipeNumberValidationError { invalid }
-
-class RecipeNumber extends FormzInput<String, RecipeNumberValidationError> {
-  const RecipeNumber.pure() : super.pure('');
-  const RecipeNumber.dirty([String value = '']) : super.dirty(value);
-
-  @override
-  RecipeNumberValidationError? validator(String? value) {
-    return value?.isNotEmpty == true
-        ? null
-        : RecipeNumberValidationError.invalid;
   }
 }
 

--- a/lib/recipe/models/recipe_item.dart
+++ b/lib/recipe/models/recipe_item.dart
@@ -10,6 +10,7 @@ class Recipe extends Equatable {
     this.recipeType = "",
     this.recipeVolume = const RecipeVolume.pure(),
     this.ingredients = const <Ingredient>[],
+    this.probes = const <String>[],
     this.saved = false,
   }) : recipeNumber = recipeNumber ?? const Uuid().v4();
 
@@ -18,6 +19,7 @@ class Recipe extends Equatable {
   final String recipeType;
   final RecipeVolume recipeVolume;
   final List<Ingredient> ingredients;
+  final List<String> probes;
   final bool saved;
 
   Recipe copyWith({
@@ -26,6 +28,7 @@ class Recipe extends Equatable {
     String? recipeType,
     RecipeVolume? recipeVolume,
     List<Ingredient>? ingredients,
+    List<String>? probes,
     bool? saved,
   }) {
     return Recipe(
@@ -34,6 +37,7 @@ class Recipe extends Equatable {
       recipeType: recipeType ?? this.recipeType,
       recipeVolume: recipeVolume ?? this.recipeVolume,
       ingredients: ingredients ?? this.ingredients,
+      probes: probes ?? this.probes,
       saved: saved ?? this.saved,
     );
   }
@@ -45,6 +49,7 @@ class Recipe extends Equatable {
         recipeType,
         recipeVolume,
         ingredients,
+        probes,
         saved,
       ];
 }

--- a/lib/recipe/view/ingredient_page.dart
+++ b/lib/recipe/view/ingredient_page.dart
@@ -14,14 +14,15 @@ class IngredientPage extends StatelessWidget {
       return Scaffold(
           appBar: AppBar(title: const Text('New Ingredient')),
           floatingActionButton: FloatingActionButton.extended(
-              label: const Text("Save Ingredient"), // TODO: pop page
+              label: const Text("Save Ingredient"),
               icon: const Icon(Icons.save_sharp),
               onPressed: () => {
                     context.read<RecipeBloc>().add(IngredientStatusChanged(
                         recipe: state.recipes[recipeIndex],
                         ingredient: state
                             .recipes[recipeIndex].ingredients[ingredientIndex],
-                        ingredientSaved: true))
+                        ingredientSaved: true)),
+                    Navigator.pop(context)
                   }),
           body: IngredientForm(recipeIndex, ingredientIndex));
     });

--- a/lib/recipe/view/recipe_probe_page.dart
+++ b/lib/recipe/view/recipe_probe_page.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gibsonify/recipe/recipe.dart';
+
+class RecipeProbePage extends StatelessWidget {
+  final int recipeIndex;
+  const RecipeProbePage(this.recipeIndex, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
+      return Scaffold(
+          appBar: AppBar(
+              title: Text(
+                  'Probe list for ${state.recipes[recipeIndex].recipeName.value}')),
+          floatingActionButton: FloatingActionButton.extended(
+              label: const Text("Add probe"),
+              icon: const Icon(Icons.add),
+              onPressed: () => {
+                    context
+                        .read<RecipeBloc>()
+                        .add(ProbeAdded(recipe: state.recipes[recipeIndex])),
+                  }),
+          body: ProbeList(recipeIndex: recipeIndex));
+    });
+  }
+}

--- a/lib/recipe/view/view.dart
+++ b/lib/recipe/view/view.dart
@@ -1,2 +1,3 @@
 export 'recipe_page.dart';
 export 'ingredient_page.dart';
+export 'recipe_probe_page.dart';

--- a/lib/recipe/widgets/ingredient_form.dart
+++ b/lib/recipe/widgets/ingredient_form.dart
@@ -206,7 +206,6 @@ class IngredientForm extends StatelessWidget {
                           recipe: state.recipes[recipeIndex]));
                 },
                 textInputAction: TextInputAction.next,
-                keyboardType: TextInputType.number,
               ),
               DropdownFormField<String>(
                 onEmptyActionPressed: () async {},

--- a/lib/recipe/widgets/probe_list.dart
+++ b/lib/recipe/widgets/probe_list.dart
@@ -27,8 +27,10 @@ class ProbeList extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: TextFormField(
-                        key: Key(state.recipes[recipeIndex].probes[index]),
-                        initialValue: state.recipes[recipeIndex].probes[index],
+                        key: Key(
+                            state.recipes[recipeIndex].probes[index]['key']),
+                        initialValue: state.recipes[recipeIndex].probes[index]
+                            ['probe'],
                         decoration: InputDecoration(
                           icon: const Icon(Icons.live_help),
                           labelText: 'Probe ${index + 1}',
@@ -38,7 +40,7 @@ class ProbeList extends StatelessWidget {
                         onChanged: (value) {
                           context.read<RecipeBloc>().add(ProbeChanged(
                               recipe: state.recipes[recipeIndex],
-                              probe: value,
+                              probeName: value,
                               probeIndex: index));
                         },
                         textInputAction: TextInputAction.next,
@@ -51,7 +53,7 @@ class ProbeList extends StatelessWidget {
 
 class DeleteProbe extends StatelessWidget {
   final Recipe recipe;
-  final String probe;
+  final Map<String, dynamic> probe;
 
   const DeleteProbe({Key? key, required this.recipe, required this.probe})
       : super(key: key);
@@ -61,7 +63,7 @@ class DeleteProbe extends StatelessWidget {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
       return AlertDialog(
         title: const Text('Delete probe'),
-        content: Text('Would you like to delete the $probe probe?'),
+        content: Text('Would you like to delete the ${probe['probe']} probe?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, 'Cancel'),

--- a/lib/recipe/widgets/probe_list.dart
+++ b/lib/recipe/widgets/probe_list.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gibsonify/recipe/recipe.dart';
+
+class ProbeList extends StatelessWidget {
+  final int recipeIndex;
+
+  const ProbeList({Key? key, required this.recipeIndex}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
+      return ListView.builder(
+          padding: const EdgeInsets.all(2.0),
+          itemCount: state.recipes[recipeIndex].probes.length,
+          itemBuilder: (context, index) {
+            return Card(
+                child: InkWell(
+                    onLongPress: () => {
+                          showDialog<String>(
+                              context: context,
+                              builder: (BuildContext context) => DeleteProbe(
+                                  recipe: state.recipes[recipeIndex],
+                                  probe:
+                                      state.recipes[recipeIndex].probes[index]))
+                        },
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: TextFormField(
+                        key: Key(state.recipes[recipeIndex].probes[index]),
+                        initialValue: state.recipes[recipeIndex].probes[index],
+                        decoration: InputDecoration(
+                          icon: const Icon(Icons.live_help),
+                          labelText: 'Probe ${index + 1}',
+                          helperText:
+                              'Recipe probe - e.g. Which flour did you use to make roti?',
+                        ),
+                        onChanged: (value) {
+                          context.read<RecipeBloc>().add(ProbeChanged(
+                              recipe: state.recipes[recipeIndex],
+                              probe: value,
+                              probeIndex: index));
+                        },
+                        textInputAction: TextInputAction.next,
+                      ),
+                    )));
+          });
+    });
+  }
+}
+
+class DeleteProbe extends StatelessWidget {
+  final Recipe recipe;
+  final String probe;
+
+  const DeleteProbe({Key? key, required this.recipe, required this.probe})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
+      return AlertDialog(
+        title: const Text('Delete probe'),
+        content: Text('Would you like to delete the $probe probe?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'Cancel'),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => {
+              context
+                  .read<RecipeBloc>()
+                  .add(ProbeDeleted(recipe: recipe, probe: probe)),
+              Navigator.pop(context, 'OK')
+            },
+            child: const Text('OK'),
+          ),
+        ],
+      );
+    });
+  }
+}

--- a/lib/recipe/widgets/recipe_screen.dart
+++ b/lib/recipe/widgets/recipe_screen.dart
@@ -21,12 +21,13 @@ class RecipeScreen extends StatelessWidget {
               children: <Widget>[
                 FloatingActionButton.extended(
                     heroTag: null,
-                    label: const Text("Save Recipe"), // TODO: pop page
+                    label: const Text("Save Recipe"),
                     icon: const Icon(Icons.save_sharp),
                     onPressed: () => {
                           context.read<RecipeBloc>().add(RecipeStatusChanged(
                               recipe: state.recipes[recipeIndex],
-                              recipeSaved: true))
+                              recipeSaved: true)),
+                          Navigator.pop(context)
                         }),
                 const SizedBox(
                   height: 10,

--- a/lib/recipe/widgets/recipe_screen.dart
+++ b/lib/recipe/widgets/recipe_screen.dart
@@ -174,9 +174,6 @@ class Ingredients extends StatelessWidget {
               itemBuilder: (context, index) {
                 return Card(
                     child: ListTile(
-                        // TODO: Fix ingredients not updating
-                        // key: Key(state.recipes[recipeIndex].ingredients[index]
-                        //     .name.value),
                         title: Text(state.recipes[recipeIndex]
                             .ingredients[index].name.value),
                         subtitle: Text(state.recipes[recipeIndex]

--- a/lib/recipe/widgets/recipe_screen.dart
+++ b/lib/recipe/widgets/recipe_screen.dart
@@ -13,6 +13,13 @@ class RecipeScreen extends StatelessWidget {
       return Scaffold(
           appBar: AppBar(
             title: const Text('Add a new recipe'),
+            actions: [
+              IconButton(
+                  onPressed: () => Navigator.pushNamed(
+                      context, PageRouter.recipeProbe,
+                      arguments: recipeIndex),
+                  icon: const Icon(Icons.help))
+            ],
           ),
           body: RecipeForm(recipeIndex),
           floatingActionButton: Column(

--- a/lib/recipe/widgets/recipe_screen.dart
+++ b/lib/recipe/widgets/recipe_screen.dart
@@ -183,8 +183,52 @@ class Ingredients extends StatelessWidget {
                               Navigator.pushNamed(
                                   context, PageRouter.ingredient,
                                   arguments: [recipeIndex, index])
+                            },
+                        onLongPress: () => {
+                              showDialog<String>(
+                                  context: context,
+                                  builder: (BuildContext context) =>
+                                      DeleteIngredient(
+                                          recipe: state.recipes[recipeIndex],
+                                          ingredient: state.recipes[recipeIndex]
+                                              .ingredients[index]))
                             }));
               }));
+    });
+  }
+}
+
+class DeleteIngredient extends StatelessWidget {
+  final Recipe recipe;
+  final Ingredient ingredient;
+
+  const DeleteIngredient(
+      {Key? key, required this.recipe, required this.ingredient})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    String ingredientName = ingredient.name.value;
+    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
+      return AlertDialog(
+        title: const Text('Delete ingredient'),
+        content:
+            Text('Would you like to delete the $ingredientName ingredient?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, 'Cancel'),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => {
+              context.read<RecipeBloc>().add(
+                  IngredientDeleted(recipe: recipe, ingredient: ingredient)),
+              Navigator.pop(context, 'OK')
+            },
+            child: const Text('OK'),
+          ),
+        ],
+      );
     });
   }
 }

--- a/lib/recipe/widgets/recipe_screen.dart
+++ b/lib/recipe/widgets/recipe_screen.dart
@@ -108,20 +108,13 @@ class RecipeNumberInput extends StatelessWidget {
     return BlocBuilder<RecipeBloc, RecipeState>(
       builder: (context, state) {
         return TextFormField(
-          initialValue: state.recipes[recipeIndex].recipeNumber.value,
-          decoration: InputDecoration(
-            icon: const Icon(Icons.format_list_numbered),
+          key: Key(state.recipes[recipeIndex].recipeNumber),
+          initialValue: state.recipes[recipeIndex].recipeNumber,
+          decoration: const InputDecoration(
+            icon: Icon(Icons.format_list_numbered),
             labelText: 'Recipe Number',
-            errorText: state.recipes[recipeIndex].recipeNumber.invalid
-                ? 'Enter recipe number'
-                : null,
           ),
           enabled: false,
-          onChanged: (value) {
-            // TODO: investigate if this is needed anymore
-            context.read<RecipeBloc>().add(RecipeNumberChanged(
-                recipeNumber: value, recipe: state.recipes[recipeIndex]));
-          },
           textInputAction: TextInputAction.next,
           keyboardType: TextInputType.number,
         );

--- a/lib/recipe/widgets/recipe_screen.dart
+++ b/lib/recipe/widgets/recipe_screen.dart
@@ -111,12 +111,13 @@ class RecipeNumberInput extends StatelessWidget {
           decoration: InputDecoration(
             icon: const Icon(Icons.format_list_numbered),
             labelText: 'Recipe Number',
-            helperText: 'Number of recipe e.g. 9001',
             errorText: state.recipes[recipeIndex].recipeNumber.invalid
                 ? 'Enter recipe number'
                 : null,
           ),
+          enabled: false,
           onChanged: (value) {
+            // TODO: investigate if this is needed anymore
             context.read<RecipeBloc>().add(RecipeNumberChanged(
                 recipeNumber: value, recipe: state.recipes[recipeIndex]));
           },

--- a/lib/recipe/widgets/widgets.dart
+++ b/lib/recipe/widgets/widgets.dart
@@ -1,2 +1,3 @@
 export 'recipe_screen.dart';
 export 'ingredient_form.dart';
+export 'probe_list.dart';


### PR DESCRIPTION
This PR implements standard, modified and non-standard recipe types, with recipe number handling and recipe deletion.

Ingredient deletion is also implemented.

Recipe probes (adding, deleting and modifying) are also implemented.

A future PR may seek to refactor duplicate code between item (recipe, ingredient, probe) deletion widgets.