### PR TITLE
ci: add commitizen pre commit hook and gh action

### DIFF
--- a/.github/workflows/commitizen-check.yml
+++ b/.github/workflows/commitizen-check.yml
@@ -1,0 +1,22 @@
+name: commitizen-check-commits
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  python-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install Commitizen
+    - name: Run commitizen check
+      run: |
+        cz check --rev-range 57b44180fbc245a2e88ecc2f386a3b177ed73e69..HEAD

--- a/.github/workflows/commitizen-check.yml
+++ b/.github/workflows/commitizen-check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+---
+repos:
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v1.17.0
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,7 +60,13 @@ The underlying classes used by the BLoC of each feature are in the `models` subd
 
 This project follows a simplified gitflow branch structure and [Conventional Commits](https://www.conventionalcommits.org/). The main branch is `main`, which contains both the active development source code and the source of stable release versions of Gibsonify. These stable versions are in commits with tags containing the given version number, e.g. `1.0.0`. The `main` branch shouldn't be directly commited to, as commits should be made into branches branched _out of_ the `main` branch, e.g. `feat/add-awesome-feature`. These are then merged to `main` after passing tests and being approved.
 
-To contribute, open a pull request (PR) from your branch to the `main` branch, naming your PR according to Conventional Commits, e.g. `feat: add awesome feature`. Your commits should also follow Conventional Commits, and it is recommended to use [Commitizen](https://commitizen-tools.github.io/commitizen/), which creates conventional commits for you using `cz c`. For major changes, please open an issue first to discuss what you would like to change.
+To contribute, open a pull request (PR) from your branch to the `main` branch, naming your PR according to Conventional Commits, e.g. `feat: add awesome feature`. For major changes, please open an issue first to discuss what you would like to change.
+
+Your commits should also follow Conventional Commits, and it is recommended to use [Commitizen](https://commitizen-tools.github.io/commitizen/), which creates conventional commits for you using `cz c`. The compliance of each commit can be automatically checked by [pre-commit](https://pre-commit.com/), by installing it as outlined [here](https://pre-commit.com/#installation), and installing the commitizen hook
+
+```bash
+pre-commit install --hook-type commit-msg
+```
 
 All changes are documented in `CHANGELOG.md`, which is generated using commitizen as well. After a PR is approved, run the following to update the changelog
 


### PR DESCRIPTION
Add a pre-commit hook to check last commit and GitHub action to check all commits for Conventional Commits compliance, starting from the commit with hash `57b44180fbc245a2e88ecc2f386a3b177ed73e69`, which is the last non-compliant commit. Update corresponding documentation.