### PR TITLE
feat: add settings help page with app information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Feat
+
+- **settings**: add source code link to settings help page
+- **settings**: show copyright in settings help page
+- add settings help page with app version
+- update and simplify settings screen
+- update item deletion
+- add delete dialog to fourth pass
+- simplify slidable background red color
+- add long-press-to-delete option to third pass
+- add delete dialog to third pass
+- add long-press-to-delete option to first pass
+- add delete dialog to first pass
+- add long-press-to-delete recipe option
+- standardize delete dialogs
+- add long-press-to-delete collection option
+- change collection form fields to tiles
+- add deletion dialog to collections screen
+- reverse slide to delete direction
+- trim ingredient list and add generating script
+- add script for generating ingredient list
+
 ### Refactor
 
 - **collection**: move food item deletion dialog class
@@ -21,23 +43,6 @@ All notable changes to this project will be documented in this file.
 
 - **collection**: temporarily remove long-press-to-delete
 - fix wrongly named map key for argument passing for page navigation
-
-### Feat
-
-- add delete dialog to fourth pass
-- simplify slidable background red color
-- add long-press-to-delete option to third pass
-- add delete dialog to third pass
-- add long-press-to-delete option to first pass
-- add delete dialog to first pass
-- add long-press-to-delete recipe option
-- standardize delete dialogs
-- add long-press-to-delete collection option
-- change collection form fields to tiles
-- add deletion dialog to collections screen
-- reverse slide to delete direction
-- trim ingredient list and add generating script
-- add script for generating ingredient list
 
 ## 1.1.0 (2022-02-21)
 

--- a/lib/home/widgets/settings_screen.dart
+++ b/lib/home/widgets/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gibsonify/navigation/navigation.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({Key? key}) : super(key: key);
@@ -6,7 +7,15 @@ class SettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title: const Text('Settings')),
+        appBar: AppBar(
+          title: const Text('Settings'),
+          actions: [
+            IconButton(
+                onPressed: () =>
+                    Navigator.pushNamed(context, PageRouter.settingsHelp),
+                icon: const Icon(Icons.help))
+          ],
+        ),
         body: const Center(child: Text('No settings currently available')));
   }
 }

--- a/lib/home/widgets/settings_screen.dart
+++ b/lib/home/widgets/settings_screen.dart
@@ -1,17 +1,12 @@
 import 'package:flutter/material.dart';
 
-class SettingsScreen extends StatefulWidget {
+class SettingsScreen extends StatelessWidget {
   const SettingsScreen({Key? key}) : super(key: key);
 
-  @override
-  _SettingsScreenState createState() => _SettingsScreenState();
-}
-
-class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(title: const Text('Settings')),
-        body: const Center(child: Text('Various Settings')));
+        body: const Center(child: Text('No settings currently available')));
   }
 }

--- a/lib/navigation/models/page_router.dart
+++ b/lib/navigation/models/page_router.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:gibsonify/home/home.dart';
 import 'package:gibsonify/collection/collection.dart';
 import 'package:gibsonify/recipe/recipe.dart';
+import 'package:gibsonify/settings/settings.dart';
 
 class PageRouter {
   static const home = '/';
@@ -16,6 +17,7 @@ class PageRouter {
   static const thirdPassHelp = '/thirdpasshelp';
   static const chooseRecipe = '/chooserecipe';
   static const finishCollection = '/finishcollection';
+  static const settingsHelp = '/settingshelp';
 
   static Route route(RouteSettings routeSettings) {
     switch (routeSettings.name) {
@@ -58,6 +60,8 @@ class PageRouter {
             foodItemDescription: args['foodItemDescription']));
       case finishCollection:
         return _buildRoute(const FinishCollectionPage());
+      case settingsHelp:
+        return _buildRoute(const SettingsHelpPage());
       default:
         throw Exception('Page does not exist!');
     }

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -1,0 +1,1 @@
+export 'view/settings_help_page.dart';

--- a/lib/settings/view/settings_help_page.dart
+++ b/lib/settings/view/settings_help_page.dart
@@ -41,6 +41,10 @@ class _SettingsHelpPageState extends State<SettingsHelpPage> {
             title: const Text('App version'),
             subtitle: Text(_packageInfo.version),
           ),
+          const ListTile(
+            title: Text('© DigitalNutritionalAssessment'),
+            subtitle: Text('Licensed under the Apache 2.0 license'),
+          )
         ]));
   }
 }

--- a/lib/settings/view/settings_help_page.dart
+++ b/lib/settings/view/settings_help_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class SettingsHelpPage extends StatefulWidget {
   // TODO: Once there is more functionality in settings, move the logic
@@ -19,6 +20,9 @@ class _SettingsHelpPageState extends State<SettingsHelpPage> {
     buildSignature: 'Unknown',
   );
 
+  final String _gibsonifyRepositoryUrl =
+      'https://github.com/DigitalNutritionalAssessment/gibsonify';
+
   @override
   void initState() {
     super.initState();
@@ -32,6 +36,18 @@ class _SettingsHelpPageState extends State<SettingsHelpPage> {
     });
   }
 
+  void _launchUrl() async {
+    try {
+      await launch(_gibsonifyRepositoryUrl);
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(content: Text('Could not launch $_gibsonifyRepositoryUrl')),
+        );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -40,6 +56,13 @@ class _SettingsHelpPageState extends State<SettingsHelpPage> {
           ListTile(
             title: const Text('App version'),
             subtitle: Text(_packageInfo.version),
+          ),
+          ListTile(
+            title: const Text('Source code'),
+            subtitle:
+                const Text('github.com/DigitalNutritionalAssessment/gibsonify'),
+            onTap: _launchUrl,
+            trailing: const Icon(Icons.open_in_new),
           ),
           const ListTile(
             title: Text('© DigitalNutritionalAssessment'),

--- a/lib/settings/view/settings_help_page.dart
+++ b/lib/settings/view/settings_help_page.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class SettingsHelpPage extends StatefulWidget {
+  // TODO: Once there is more functionality in settings, move the logic
+  // to SettingsBloc and change this to a StatelessWidget
+  const SettingsHelpPage({Key? key}) : super(key: key);
+
+  @override
+  State<SettingsHelpPage> createState() => _SettingsHelpPageState();
+}
+
+class _SettingsHelpPageState extends State<SettingsHelpPage> {
+  PackageInfo _packageInfo = PackageInfo(
+    appName: 'Unknown',
+    packageName: 'Unknown',
+    version: 'Unknown',
+    buildNumber: 'Unknown',
+    buildSignature: 'Unknown',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _initPackageInfo();
+  }
+
+  Future<void> _initPackageInfo() async {
+    final info = await PackageInfo.fromPlatform();
+    setState(() {
+      _packageInfo = info;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(title: const Text('Settings Help')),
+        body: Column(children: [
+          ListTile(
+            title: const Text('App version'),
+            subtitle: Text(_packageInfo.version),
+          ),
+        ]));
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import geolocator_apple
+import package_info_plus_macos
 import path_provider_macos
 import share_plus_macos
 import shared_preferences_macos
@@ -13,6 +14,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - FlutterMacOS (1.0.0)
   - geolocator_apple (1.2.0):
     - FlutterMacOS
+  - package_info_plus_macos (0.0.1):
+    - FlutterMacOS
   - path_provider_macos (0.0.1):
     - FlutterMacOS
   - share_plus_macos (0.0.1):
@@ -14,6 +16,7 @@ PODS:
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - geolocator_apple (from `Flutter/ephemeral/.symlinks/plugins/geolocator_apple/macos`)
+  - package_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - share_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos`)
   - shared_preferences_macos (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos`)
@@ -24,6 +27,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   geolocator_apple:
     :path: Flutter/ephemeral/.symlinks/plugins/geolocator_apple/macos
+  package_info_plus_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos
   path_provider_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
   share_plus_macos:
@@ -36,6 +41,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
   geolocator_apple: 821be05bbdb1b49500e029ebcbf2d6acf2dfb966
+  package_info_plus_macos: f010621b07802a241d96d01876d6705f15e77c1c
   path_provider_macos: 160cab0d5461f0c0e02995469a98f24bdb9a3f1f
   share_plus_macos: 853ee48e7dce06b633998ca0735d482dd671ade4
   shared_preferences_macos: 480ce071d0666e37cef23fe6c702293a3d21799e

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -282,6 +282,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:
@@ -401,6 +408,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
+  package_info_plus_linux:
+    dependency: transitive
+    description:
+      name: package_info_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  package_info_plus_macos:
+    dependency: transitive
+    description:
+      name: package_info_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  package_info_plus_web:
+    dependency: transitive
+    description:
+      name: package_info_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  package_info_plus_windows:
+    dependency: transitive
+    description:
+      name: package_info_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -764,7 +764,7 @@ packages:
     source: hosted
     version: "1.3.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   intl_phone_field: ^3.0.1
   share_plus: ^3.0.5
   path_provider: ^2.0.9
+  package_info_plus: ^1.4.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   share_plus: ^3.0.5
   path_provider: ^2.0.9
   package_info_plus: ^1.4.0
+  url_launcher: ^6.0.20
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds a `settings` module with `SettingsHelpPage` that shows app version, source code link and copyright information.

This stemmed from my laziness of having to check which app version I have installed on my phone. In the `<Future>`, this page might be extended with a debug log, or contact information. Inspiration came from the [Signal app](https://signal.org) Help Page:

![signal_help_page](https://user-images.githubusercontent.com/45038919/156670094-c87aca00-006d-4600-95ae-68993294ada8.png)

For a small PR, it adds two more dependencies — [url_launcher](https://pub.dev/packages/url_launcher) and [package_info_plus](https://pub.dev/packages/package_info_plus), but both are quite popular [Flutter Favorite](https://flutter.dev/docs/development/packages-and-plugins/favorites) plugins with many likes, and since they'll just be used on this page, they can be removed if not needed in the future (or if something with them breaks).

Lmk what you think @sshazril.