### PR TITLE
feat: implement recipe and collection feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,51 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Refactor
+
+- add new viewedFromCollection parameter for code readability
+- remove unnecessary argument for context popping
+- rename edit probe page
+- **recipe**: move showIngredients and showMeasurements to recipe bloc state
+- **recipe**: rename modified recipe function for clarity
+- **recipe**: handle unnamed ingredients
+- **recipe**: handle unnamed recipes and probes
+- **recipe**: remove dialog ingredient deletion
+- **recipe**: remove ability to create standard recipe via collection
+- **recipe**: remove slidable usage from recipes screen
+- **recipe**: refactor error conditions using utils function
+- **recipe**: set probe screen as default page for standard recipes
+- change name of food item description field to comments
+
+### Fix
+
+- **recipe**: fix render overflow error for ingredient page
+- **recipe**: update modified recipe listtile
+- **recipe**: update food description field view
+- remove error text for comments field
+- **recipe**: restrict item deletion for standard recipes
+- **recipe**: remove old modified recipe logic and fix saved recipe/ingredient logic
+
+### Feat
+
+- **recipe**: add custom cooking state field
+- **recipe**: add helper text for saved recipes
+- **recipe**: restrict saving if measurements are not filled
+- **gibsonify_api**: add new measurement checks
+- **recipe**: finalise hide ingredients and measurements feature
+- **recipe**: add toggle to hide ingredients
+- **recipe**: add toggle to hide measurements
+- **recipe**: restrict probe editting when accessing via collection
+- **recipe**: add recipe duplication feat, use modal sheet instead of slidable for deletion
+- **recipe**: add ingredient duplication feature
+- **recipe**: restrict ingredient deletion when recipe is saved
+- **recipe**: add feature to restrict input if recipe is saved
+- **recipe**: add new modified recipe implementation
+- **recipe**: add recipe duplication
+- **recipe**: add ingredients as identifier for recipes
+
 ## 1.2.0 (2022-04-18)
 
 ### Feat

--- a/lib/collection/view/choose_recipe_page.dart
+++ b/lib/collection/view/choose_recipe_page.dart
@@ -14,6 +14,7 @@ class ChooseRecipePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: RecipesScreen(
+          viewedFromCollection: true,
           assignedFoodItemId: assignedFoodItemId,
           foodItemDescription: foodItemDescription),
     );

--- a/lib/collection/view/finish_collection_page.dart
+++ b/lib/collection/view/finish_collection_page.dart
@@ -432,7 +432,7 @@ class FinishCollectionDialog extends StatelessWidget {
               'alternative, you can pause the collection.'),
           actions: [
             TextButton(
-              onPressed: () => Navigator.pop(context, 'Cancel'),
+              onPressed: () => Navigator.pop(context),
               child: const Text('Cancel'),
             ),
             TextButton(

--- a/lib/collection/widgets/delete_food_item_dialog.dart
+++ b/lib/collection/widgets/delete_food_item_dialog.dart
@@ -17,10 +17,11 @@ class DeleteFoodItemDialog extends StatelessWidget {
       builder: (context, state) {
         return AlertDialog(
           title: const Text('Delete food'),
-          content: Text('Would you like to delete the $foodItemDisplayName food?'),
+          content:
+              Text('Would you like to delete the $foodItemDisplayName food?'),
           actions: [
             TextButton(
-              onPressed: () => Navigator.pop(context, 'Cancel'),
+              onPressed: () => Navigator.pop(context),
               child: const Text('Cancel'),
             ),
             TextButton(
@@ -28,7 +29,7 @@ class DeleteFoodItemDialog extends StatelessWidget {
                 context
                     .read<CollectionBloc>()
                     .add(FoodItemDeleted(foodItem: foodItem));
-                Navigator.pop(context, 'Delete');
+                Navigator.pop(context);
               },
               child: const Text('Delete'),
             ),

--- a/lib/collection/widgets/fourth_pass_food_item_card.dart
+++ b/lib/collection/widgets/fourth_pass_food_item_card.dart
@@ -73,13 +73,10 @@ class FourthPassFoodItemCard extends StatelessWidget {
                 onTap: () =>
                     onSelectedScreenChanged!(SelectedScreen.secondPass),
                 initialValue: foodItem.description,
-                decoration: InputDecoration(
-                  icon: const Icon(Icons.info),
-                  labelText: 'Food description',
-                  helperText: 'Detailed dish description',
-                  errorText: isFieldUnmodifiedOrEmpty(foodItem.description)
-                      ? 'Enter the dish description'
-                      : null,
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.info),
+                  labelText: 'Comments',
+                  helperText: 'Optional comments about the food item',
                 ),
               ),
               TextFormField(

--- a/lib/collection/widgets/second_pass_food_item_card.dart
+++ b/lib/collection/widgets/second_pass_food_item_card.dart
@@ -106,13 +106,10 @@ class SecondPassFoodItemCard extends StatelessWidget {
                 selectedItem: foodItem.preparationMethod),
             TextFormField(
               initialValue: foodItem.description,
-              decoration: InputDecoration(
-                icon: const Icon(Icons.info),
+              decoration: const InputDecoration(
+                icon: Icon(Icons.info),
                 labelText: 'Comments',
                 helperText: 'Optional comments about the food item',
-                errorText: isFieldModifiedAndEmpty(foodItem.description)
-                    ? 'Write down the full list of ingredients'
-                    : null,
               ),
               onChanged: (value) => onDescriptionChanged!(value),
               textInputAction: TextInputAction.next,

--- a/lib/collection/widgets/second_pass_food_item_card.dart
+++ b/lib/collection/widgets/second_pass_food_item_card.dart
@@ -83,19 +83,6 @@ class SecondPassFoodItemCard extends StatelessWidget {
                 onChanged: (String? foodSource) =>
                     onSourceChanged!(foodSource!),
                 selectedItem: foodItem.source),
-            TextFormField(
-              initialValue: foodItem.description,
-              decoration: InputDecoration(
-                icon: const Icon(Icons.info),
-                labelText: 'Food ingredients',
-                helperText: 'Detailed list of ingredients',
-                errorText: isFieldModifiedAndEmpty(foodItem.description)
-                    ? 'Write down the full list of ingredients'
-                    : null,
-              ),
-              onChanged: (value) => onDescriptionChanged!(value),
-              textInputAction: TextInputAction.next,
-            ),
             DropdownSearch<String>(
                 maxHeight: 645.0,
                 dropdownSearchDecoration: InputDecoration(
@@ -117,6 +104,19 @@ class SecondPassFoodItemCard extends StatelessWidget {
                 onChanged: (String? preparationMethod) =>
                     onPreparationMethodChanged!(preparationMethod!),
                 selectedItem: foodItem.preparationMethod),
+            TextFormField(
+              initialValue: foodItem.description,
+              decoration: InputDecoration(
+                icon: const Icon(Icons.info),
+                labelText: 'Comments',
+                helperText: 'Optional comments about the food item',
+                errorText: isFieldModifiedAndEmpty(foodItem.description)
+                    ? 'Write down the full list of ingredients'
+                    : null,
+              ),
+              onChanged: (value) => onDescriptionChanged!(value),
+              textInputAction: TextInputAction.next,
+            ),
             TextFormField(
               initialValue: foodItem.recipe?.name ?? '',
               readOnly: true,

--- a/lib/collection/widgets/third_pass_screen.dart
+++ b/lib/collection/widgets/third_pass_screen.dart
@@ -109,14 +109,14 @@ class DeleteFoodItemMeasurementDialog extends StatelessWidget {
           content: const Text('Would you like to delete the measurement?'),
           actions: [
             TextButton(
-              onPressed: () => Navigator.pop(context, 'Cancel'),
+              onPressed: () => Navigator.pop(context),
               child: const Text('Cancel'),
             ),
             TextButton(
               onPressed: () {
                 context.read<CollectionBloc>().add(FoodItemMeasurementDeleted(
                     foodItem: foodItem, measurementIndex: measurementIndex));
-                Navigator.pop(context, 'Delete');
+                Navigator.pop(context);
               },
               child: const Text('Delete'),
             ),

--- a/lib/home/view/home_page.dart
+++ b/lib/home/view/home_page.dart
@@ -14,7 +14,7 @@ class _HomePageState extends State<HomePage> {
 
   final List<Widget> _screens = [
     const CollectionsScreen(),
-    const RecipesScreen(),
+    const RecipesScreen(viewedFromCollection: false),
     const SyncScreen(),
     const SettingsScreen(),
   ];

--- a/lib/home/widgets/collections_screen.dart
+++ b/lib/home/widgets/collections_screen.dart
@@ -192,7 +192,7 @@ class DeleteCollectionDialog extends StatelessWidget {
               'Would you like to delete the collection of $displayRespondentName?'),
           actions: [
             TextButton(
-              onPressed: () => Navigator.pop(context, 'Cancel'),
+              onPressed: () => Navigator.pop(context),
               child: const Text('Cancel'),
             ),
             TextButton(
@@ -200,7 +200,7 @@ class DeleteCollectionDialog extends StatelessWidget {
                 context
                     .read<HomeBloc>()
                     .add(GibsonsFormDeleted(id: gibsonsForm.id));
-                Navigator.pop(context, 'Delete');
+                Navigator.pop(context);
               },
               child: const Text('Delete'),
             ),

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -31,13 +31,11 @@ class RecipesScreen extends StatelessWidget {
                       child: ListTile(
                           contentPadding: const EdgeInsets.symmetric(
                               vertical: 8.0, horizontal: 10.0),
-                          title: isFieldNotNullAndNotEmpty(
-                                  recipeState.recipes[index].name)
-                              ? Text(recipeState.recipes[index].name!)
-                              : const Text('Unnamed Recipe'),
+                          title: Text(
+                              recipeState.recipes[index].recipeNameDisplay()),
                           subtitle: Text(recipeState.recipes[index].type +
                               recipeState.recipes[index]
-                                  .ingredientNamesString()),
+                                  .ingredientNamesDisplay()),
                           trailing: recipeState.recipes[index].saved
                               ? const Icon(Icons.done)
                               : const Icon(Icons.new_releases),
@@ -150,7 +148,7 @@ class RecipeOptions extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
       final List<Widget> options = [
-        ListTile(title: Text((recipe.name ?? '') + ' recipe options')),
+        ListTile(title: Text((recipe.recipeNameDisplay()) + ' options')),
         const Divider(),
         ListTile(
           leading: const Icon(Icons.copy),

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -47,43 +47,54 @@ class RecipesScreen extends StatelessWidget {
                     ),
                     child: Card(
                         child: ListTile(
-                      contentPadding: const EdgeInsets.symmetric(
-                          vertical: 8.0, horizontal: 10.0),
-                      title: isFieldNotNullAndNotEmpty(
-                              recipeState.recipes[index].name)
-                          ? Text(recipeState.recipes[index].name!)
-                          : const Text('Unnamed Recipe'),
-                      subtitle: Text(recipeState.recipes[index].type +
-                          recipeState.recipes[index].ingredientNamesString()),
-                      trailing: recipeState.recipes[index].saved
-                          ? const Icon(Icons.done)
-                          : const Icon(Icons.rotate_left_rounded),
-                      onTap: () => {
-                        context.read<RecipeBloc>().add(RecipeProbesCleared(
-                            recipe: recipeState.recipes[index])),
-                        Navigator.pushNamed(context, PageRouter.recipe,
-                            arguments: (recipeState.recipes[index].type !=
-                                    'Standard Recipe')
-                                ? {
-                                    'recipeIndex': index,
-                                    'assignedFoodItemId': assignedFoodItemId,
-                                    'foodItemDescription': foodItemDescription,
-                                    'selectedScreen':
-                                        SelectedRecipeScreen.ingredientScreen
-                                  }
-                                : {
-                                    'recipeIndex': index,
-                                    'assignedFoodItemId': assignedFoodItemId,
-                                    'foodItemDescription': foodItemDescription,
-                                    'selectedScreen':
-                                        SelectedRecipeScreen.probeScreen
-                                  })
-                      },
-                      onLongPress: () => showDialog<String>(
-                          context: context,
-                          builder: (BuildContext context) => DeleteRecipeDialog(
-                              recipe: recipeState.recipes[index])),
-                    )),
+                            contentPadding: const EdgeInsets.symmetric(
+                                vertical: 8.0, horizontal: 10.0),
+                            title: isFieldNotNullAndNotEmpty(
+                                    recipeState.recipes[index].name)
+                                ? Text(recipeState.recipes[index].name!)
+                                : const Text('Unnamed Recipe'),
+                            subtitle: Text(recipeState.recipes[index].type +
+                                recipeState.recipes[index]
+                                    .ingredientNamesString()),
+                            trailing: recipeState.recipes[index].saved
+                                ? const Icon(Icons.done)
+                                : const Icon(Icons.rotate_left_rounded),
+                            onTap: () => {
+                                  context.read<RecipeBloc>().add(
+                                      RecipeProbesCleared(
+                                          recipe: recipeState.recipes[index])),
+                                  Navigator.pushNamed(
+                                      context, PageRouter.recipe,
+                                      arguments:
+                                          (recipeState.recipes[index].type !=
+                                                  'Standard Recipe')
+                                              ? {
+                                                  'recipeIndex': index,
+                                                  'assignedFoodItemId':
+                                                      assignedFoodItemId,
+                                                  'foodItemDescription':
+                                                      foodItemDescription,
+                                                  'selectedScreen':
+                                                      SelectedRecipeScreen
+                                                          .ingredientScreen
+                                                }
+                                              : {
+                                                  'recipeIndex': index,
+                                                  'assignedFoodItemId':
+                                                      assignedFoodItemId,
+                                                  'foodItemDescription':
+                                                      foodItemDescription,
+                                                  'selectedScreen':
+                                                      SelectedRecipeScreen
+                                                          .probeScreen
+                                                })
+                                },
+                            onLongPress: () => showModalBottomSheet(
+                                context: context,
+                                builder: (context) {
+                                  return RecipeOptions(
+                                      recipe: recipeState.recipes[index]);
+                                }))),
                   );
                 }),
             floatingActionButton: Column(
@@ -161,6 +172,52 @@ class DeleteRecipeDialog extends StatelessWidget {
           ),
         ],
       );
+    });
+  }
+}
+
+class RecipeOptions extends StatelessWidget {
+  final Recipe recipe;
+
+  const RecipeOptions({Key? key, required this.recipe}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
+      final List<Widget> options = [
+        ListTile(title: Text((recipe.name ?? '') + ' recipe options')),
+        const Divider(),
+        ListTile(
+          leading: const Icon(Icons.copy),
+          title: const Text('Duplicate'),
+          onTap: () => {
+            context.read<RecipeBloc>().add(RecipeDuplicated(recipe: recipe)),
+            context.read<RecipeBloc>().add(const RecipesSaved()),
+            Navigator.pop(context, 'Duplicate')
+          },
+        ),
+        ListTile(
+          leading: const Icon(Icons.delete),
+          title: const Text('Delete'),
+          onTap: () => {
+            context.read<RecipeBloc>().add(RecipeDeleted(recipe: recipe)),
+            context.read<RecipeBloc>().add(const RecipesSaved()),
+            Navigator.pop(context, 'Delete')
+          },
+        )
+      ];
+      // if (recipe.type == "Standard Recipe") {
+      //   options.add(ListTile(
+      //     leading: const Icon(Icons.edit),
+      //     title: const Text('Create modified recipe'),
+      //     onTap: () => {
+      //       context.read<RecipeBloc>().add(RecipeDeleted(recipe: recipe)),
+      //       context.read<RecipeBloc>().add(const RecipesSaved()),
+      //       Navigator.pop(context, 'Delete')
+      //     },
+      //   ));
+      // }
+      return Wrap(children: options);
     });
   }
 }

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -56,10 +56,8 @@ class RecipesScreen extends StatelessWidget {
                         context.read<RecipeBloc>().add(RecipeProbesCleared(
                             recipe: recipeState.recipes[index])),
                         Navigator.pushNamed(context, PageRouter.recipe,
-                            arguments: (assignedFoodItemId == null ||
-                                    recipeState.recipes[index].probes.isEmpty ||
-                                    recipeState.recipes[index].type !=
-                                        'Standard Recipe')
+                            arguments: (recipeState.recipes[index].type !=
+                                    'Standard Recipe')
                                 ? {
                                     'recipeIndex': index,
                                     'assignedFoodItemId': assignedFoodItemId,

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -43,6 +43,19 @@ class RecipesScreen extends StatelessWidget {
                                 context.read<RecipeBloc>().add(
                                     RecipeProbesCleared(
                                         recipe: recipeState.recipes[index])),
+                                if (assignedFoodItemId != null &&
+                                    recipeState.recipes[index].type ==
+                                        'Standard Recipe')
+                                  {
+                                    context.read<RecipeBloc>().add(
+                                        RecipeShowMeasurementsChanged(
+                                            showMeasurements: false,
+                                            recipeIndex: index)),
+                                    context.read<RecipeBloc>().add(
+                                        RecipeShowIngredientsChanged(
+                                            showIngredients: false,
+                                            recipeIndex: index)),
+                                  },
                                 Navigator.pushNamed(context, PageRouter.recipe,
                                     arguments: (recipeState
                                                 .recipes[index].type !=

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -58,7 +58,7 @@ class RecipesScreen extends StatelessWidget {
                                     .ingredientNamesString()),
                             trailing: recipeState.recipes[index].saved
                                 ? const Icon(Icons.done)
-                                : const Icon(Icons.rotate_left_rounded),
+                                : const Icon(Icons.new_releases),
                             onTap: () => {
                                   context.read<RecipeBloc>().add(
                                       RecipeProbesCleared(
@@ -93,7 +93,9 @@ class RecipesScreen extends StatelessWidget {
                                 context: context,
                                 builder: (context) {
                                   return RecipeOptions(
-                                      recipe: recipeState.recipes[index]);
+                                      recipe: recipeState.recipes[index],
+                                      employeeNumber:
+                                          loginState.loginInfo.employeeId!);
                                 }))),
                   );
                 }),
@@ -178,8 +180,11 @@ class DeleteRecipeDialog extends StatelessWidget {
 
 class RecipeOptions extends StatelessWidget {
   final Recipe recipe;
+  final String employeeNumber;
 
-  const RecipeOptions({Key? key, required this.recipe}) : super(key: key);
+  const RecipeOptions(
+      {Key? key, required this.recipe, required this.employeeNumber})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -191,7 +196,8 @@ class RecipeOptions extends StatelessWidget {
           leading: const Icon(Icons.copy),
           title: const Text('Duplicate'),
           onTap: () => {
-            context.read<RecipeBloc>().add(RecipeDuplicated(recipe: recipe)),
+            context.read<RecipeBloc>().add(RecipeDuplicated(
+                recipe: recipe, employeeNumber: employeeNumber)),
             context.read<RecipeBloc>().add(const RecipesSaved()),
             Navigator.pop(context, 'Duplicate')
           },
@@ -206,17 +212,18 @@ class RecipeOptions extends StatelessWidget {
           },
         )
       ];
-      // if (recipe.type == "Standard Recipe") {
-      //   options.add(ListTile(
-      //     leading: const Icon(Icons.edit),
-      //     title: const Text('Create modified recipe'),
-      //     onTap: () => {
-      //       context.read<RecipeBloc>().add(RecipeDeleted(recipe: recipe)),
-      //       context.read<RecipeBloc>().add(const RecipesSaved()),
-      //       Navigator.pop(context, 'Delete')
-      //     },
-      //   ));
-      // }
+      if (recipe.type == "Standard Recipe") {
+        options.add(ListTile(
+          leading: const Icon(Icons.edit),
+          title: const Text('Create modified recipe'),
+          onTap: () => {
+            context.read<RecipeBloc>().add(
+                RecipeModified(recipe: recipe, employeeNumber: employeeNumber)),
+            context.read<RecipeBloc>().add(const RecipesSaved()),
+            Navigator.pop(context, 'Modified')
+          },
+        ));
+      }
       return Wrap(children: options);
     });
   }

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -177,7 +177,7 @@ class RecipeOptions extends StatelessWidget {
             context.read<RecipeBloc>().add(RecipeDuplicated(
                 recipe: recipe, employeeNumber: employeeNumber)),
             context.read<RecipeBloc>().add(const RecipesSaved()),
-            Navigator.pop(context, 'Duplicate')
+            Navigator.pop(context)
           },
         ),
         ListTile(
@@ -186,7 +186,7 @@ class RecipeOptions extends StatelessWidget {
           onTap: () => {
             context.read<RecipeBloc>().add(RecipeDeleted(recipe: recipe)),
             context.read<RecipeBloc>().add(const RecipesSaved()),
-            Navigator.pop(context, 'Delete')
+            Navigator.pop(context)
           },
         )
       ];
@@ -198,7 +198,7 @@ class RecipeOptions extends StatelessWidget {
             context.read<RecipeBloc>().add(ModifiedRecipeCreated(
                 recipe: recipe, employeeNumber: employeeNumber)),
             context.read<RecipeBloc>().add(const RecipesSaved()),
-            Navigator.pop(context, 'Modified')
+            Navigator.pop(context)
           },
         ));
       }

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -188,8 +188,8 @@ class RecipeOptions extends StatelessWidget {
           leading: const Icon(Icons.edit),
           title: const Text('Create modified recipe'),
           onTap: () => {
-            context.read<RecipeBloc>().add(
-                RecipeModified(recipe: recipe, employeeNumber: employeeNumber)),
+            context.read<RecipeBloc>().add(ModifiedRecipeCreated(
+                recipe: recipe, employeeNumber: employeeNumber)),
             context.read<RecipeBloc>().add(const RecipesSaved()),
             Navigator.pop(context, 'Modified')
           },

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -4,7 +4,6 @@ import 'package:gibsonify/navigation/navigation.dart';
 import 'package:gibsonify/recipe/recipe.dart';
 import 'package:gibsonify/login/login.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
-import 'package:flutter_slidable/flutter_slidable.dart';
 
 class RecipesScreen extends StatelessWidget {
   final String? assignedFoodItemId;
@@ -28,76 +27,56 @@ class RecipesScreen extends StatelessWidget {
                 padding: const EdgeInsets.all(2.0),
                 itemCount: recipeState.recipes.length,
                 itemBuilder: (context, index) {
-                  return Slidable(
-                    endActionPane: ActionPane(
-                      motion: const ScrollMotion(),
-                      children: [
-                        SlidableAction(
-                          onPressed: (context) => showDialog<String>(
+                  return Card(
+                      child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(
+                              vertical: 8.0, horizontal: 10.0),
+                          title: isFieldNotNullAndNotEmpty(
+                                  recipeState.recipes[index].name)
+                              ? Text(recipeState.recipes[index].name!)
+                              : const Text('Unnamed Recipe'),
+                          subtitle: Text(recipeState.recipes[index].type +
+                              recipeState.recipes[index]
+                                  .ingredientNamesString()),
+                          trailing: recipeState.recipes[index].saved
+                              ? const Icon(Icons.done)
+                              : const Icon(Icons.new_releases),
+                          onTap: () => {
+                                context.read<RecipeBloc>().add(
+                                    RecipeProbesCleared(
+                                        recipe: recipeState.recipes[index])),
+                                Navigator.pushNamed(context, PageRouter.recipe,
+                                    arguments: (recipeState
+                                                .recipes[index].type !=
+                                            'Standard Recipe')
+                                        ? {
+                                            'recipeIndex': index,
+                                            'assignedFoodItemId':
+                                                assignedFoodItemId,
+                                            'foodItemDescription':
+                                                foodItemDescription,
+                                            'selectedScreen':
+                                                SelectedRecipeScreen
+                                                    .ingredientScreen
+                                          }
+                                        : {
+                                            'recipeIndex': index,
+                                            'assignedFoodItemId':
+                                                assignedFoodItemId,
+                                            'foodItemDescription':
+                                                foodItemDescription,
+                                            'selectedScreen':
+                                                SelectedRecipeScreen.probeScreen
+                                          })
+                              },
+                          onLongPress: () => showModalBottomSheet(
                               context: context,
-                              builder: (BuildContext context) =>
-                                  DeleteRecipeDialog(
-                                      recipe: recipeState.recipes[index])),
-                          backgroundColor: Colors.red,
-                          foregroundColor: Colors.white,
-                          icon: Icons.delete,
-                          label: 'Delete',
-                        )
-                      ],
-                    ),
-                    child: Card(
-                        child: ListTile(
-                            contentPadding: const EdgeInsets.symmetric(
-                                vertical: 8.0, horizontal: 10.0),
-                            title: isFieldNotNullAndNotEmpty(
-                                    recipeState.recipes[index].name)
-                                ? Text(recipeState.recipes[index].name!)
-                                : const Text('Unnamed Recipe'),
-                            subtitle: Text(recipeState.recipes[index].type +
-                                recipeState.recipes[index]
-                                    .ingredientNamesString()),
-                            trailing: recipeState.recipes[index].saved
-                                ? const Icon(Icons.done)
-                                : const Icon(Icons.new_releases),
-                            onTap: () => {
-                                  context.read<RecipeBloc>().add(
-                                      RecipeProbesCleared(
-                                          recipe: recipeState.recipes[index])),
-                                  Navigator.pushNamed(
-                                      context, PageRouter.recipe,
-                                      arguments:
-                                          (recipeState.recipes[index].type !=
-                                                  'Standard Recipe')
-                                              ? {
-                                                  'recipeIndex': index,
-                                                  'assignedFoodItemId':
-                                                      assignedFoodItemId,
-                                                  'foodItemDescription':
-                                                      foodItemDescription,
-                                                  'selectedScreen':
-                                                      SelectedRecipeScreen
-                                                          .ingredientScreen
-                                                }
-                                              : {
-                                                  'recipeIndex': index,
-                                                  'assignedFoodItemId':
-                                                      assignedFoodItemId,
-                                                  'foodItemDescription':
-                                                      foodItemDescription,
-                                                  'selectedScreen':
-                                                      SelectedRecipeScreen
-                                                          .probeScreen
-                                                })
-                                },
-                            onLongPress: () => showModalBottomSheet(
-                                context: context,
-                                builder: (context) {
-                                  return RecipeOptions(
-                                      recipe: recipeState.recipes[index],
-                                      employeeNumber:
-                                          loginState.loginInfo.employeeId!);
-                                }))),
-                  );
+                              builder: (context) {
+                                return RecipeOptions(
+                                    recipe: recipeState.recipes[index],
+                                    employeeNumber:
+                                        loginState.loginInfo.employeeId!);
+                              })));
                 }),
             floatingActionButton: Column(
                 mainAxisAlignment: MainAxisAlignment.end,
@@ -144,36 +123,6 @@ class RecipesScreen extends StatelessWidget {
                           })
                 ]));
       });
-    });
-  }
-}
-
-class DeleteRecipeDialog extends StatelessWidget {
-  final Recipe recipe;
-
-  const DeleteRecipeDialog({Key? key, required this.recipe}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
-      return AlertDialog(
-        title: const Text('Delete recipe'),
-        content: Text('Would you like to delete the ${recipe.name} recipe?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, 'Cancel'),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => {
-              context.read<RecipeBloc>().add(RecipeDeleted(recipe: recipe)),
-              context.read<RecipeBloc>().add(const RecipesSaved()),
-              Navigator.pop(context, 'Delete')
-            },
-            child: const Text('Delete'),
-          ),
-        ],
-      );
     });
   }
 }

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -47,8 +47,14 @@ class RecipesScreen extends StatelessWidget {
                     ),
                     child: Card(
                         child: ListTile(
-                      title: Text(recipeState.recipes[index].name ?? ''),
-                      subtitle: Text(recipeState.recipes[index].type),
+                      contentPadding: const EdgeInsets.symmetric(
+                          vertical: 8.0, horizontal: 10.0),
+                      title: isFieldNotNullAndNotEmpty(
+                              recipeState.recipes[index].name)
+                          ? Text(recipeState.recipes[index].name!)
+                          : const Text('Unnamed Recipe'),
+                      subtitle: Text(recipeState.recipes[index].type +
+                          recipeState.recipes[index].ingredientNamesString()),
                       trailing: recipeState.recipes[index].saved
                           ? const Icon(Icons.done)
                           : const Icon(Icons.rotate_left_rounded),

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -82,26 +82,37 @@ class RecipesScreen extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.end,
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: <Widget>[
-                  FloatingActionButton.extended(
-                      heroTag: null,
-                      label: const Text("Standard Recipe"),
-                      icon: const Icon(Icons.add),
-                      onPressed: () => {
-                            context.read<RecipeBloc>().add(RecipeAdded(
-                                employeeNumber:
-                                    loginState.loginInfo.employeeId!,
-                                type: "Standard Recipe")),
-                            Navigator.pushNamed(context, PageRouter.recipe,
-                                arguments: {
-                                  'recipeIndex': recipeState.recipes.length,
-                                  'assignedFoodItemId': assignedFoodItemId,
-                                  'foodItemDescription': foodItemDescription,
-                                  'selectedScreen':
-                                      SelectedRecipeScreen.probeScreen
+                  Visibility(
+                    visible: assignedFoodItemId == null,
+                    child: Column(
+                      children: [
+                        FloatingActionButton.extended(
+                            heroTag: null,
+                            label: const Text("Standard Recipe"),
+                            icon: const Icon(Icons.add),
+                            onPressed: () => {
+                                  context.read<RecipeBloc>().add(RecipeAdded(
+                                      employeeNumber:
+                                          loginState.loginInfo.employeeId!,
+                                      type: "Standard Recipe")),
+                                  Navigator.pushNamed(
+                                      context, PageRouter.recipe,
+                                      arguments: {
+                                        'recipeIndex':
+                                            recipeState.recipes.length,
+                                        'assignedFoodItemId':
+                                            assignedFoodItemId,
+                                        'foodItemDescription':
+                                            foodItemDescription,
+                                        'selectedScreen':
+                                            SelectedRecipeScreen.probeScreen
+                                      }),
                                 }),
-                          }),
-                  const SizedBox(
-                    height: 10,
+                        const SizedBox(
+                          height: 10,
+                        ),
+                      ],
+                    ),
                   ),
                   FloatingActionButton.extended(
                       heroTag: null,

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -6,11 +6,15 @@ import 'package:gibsonify/login/login.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
 
 class RecipesScreen extends StatelessWidget {
+  final bool viewedFromCollection;
   final String? assignedFoodItemId;
   final String? foodItemDescription;
 
   const RecipesScreen(
-      {Key? key, this.assignedFoodItemId, this.foodItemDescription})
+      {Key? key,
+      required this.viewedFromCollection,
+      this.assignedFoodItemId,
+      this.foodItemDescription})
       : super(key: key);
 
   @override
@@ -20,7 +24,7 @@ class RecipesScreen extends StatelessWidget {
           builder: (context, recipeState) {
         return Scaffold(
             appBar: AppBar(
-                title: assignedFoodItemId == null
+                title: !viewedFromCollection
                     ? const Text('Recipes')
                     : const Text('Choose a Recipe')),
             body: ListView.builder(
@@ -43,7 +47,7 @@ class RecipesScreen extends StatelessWidget {
                                 context.read<RecipeBloc>().add(
                                     RecipeProbesCleared(
                                         recipe: recipeState.recipes[index])),
-                                if (assignedFoodItemId != null &&
+                                if (viewedFromCollection &&
                                     recipeState.recipes[index].type ==
                                         'Standard Recipe')
                                   {
@@ -69,6 +73,8 @@ class RecipesScreen extends StatelessWidget {
                                             'Standard Recipe')
                                         ? {
                                             'recipeIndex': index,
+                                            'viewedFromCollection':
+                                                viewedFromCollection,
                                             'assignedFoodItemId':
                                                 assignedFoodItemId,
                                             'foodItemDescription':
@@ -79,6 +85,8 @@ class RecipesScreen extends StatelessWidget {
                                           }
                                         : {
                                             'recipeIndex': index,
+                                            'viewedFromCollection':
+                                                viewedFromCollection,
                                             'assignedFoodItemId':
                                                 assignedFoodItemId,
                                             'foodItemDescription':
@@ -101,7 +109,7 @@ class RecipesScreen extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: <Widget>[
                   Visibility(
-                    visible: assignedFoodItemId == null,
+                    visible: !viewedFromCollection,
                     child: Column(
                       children: [
                         FloatingActionButton.extended(
@@ -118,6 +126,8 @@ class RecipesScreen extends StatelessWidget {
                                       arguments: {
                                         'recipeIndex':
                                             recipeState.recipes.length,
+                                        'viewedFromCollection':
+                                            viewedFromCollection,
                                         'assignedFoodItemId':
                                             assignedFoodItemId,
                                         'foodItemDescription':
@@ -144,6 +154,7 @@ class RecipesScreen extends StatelessWidget {
                             Navigator.pushNamed(context, PageRouter.recipe,
                                 arguments: {
                                   'recipeIndex': recipeState.recipes.length,
+                                  'viewedFromCollection': viewedFromCollection,
                                   'assignedFoodItemId': assignedFoodItemId,
                                   'foodItemDescription': foodItemDescription,
                                   'selectedScreen':

--- a/lib/home/widgets/recipes_screen.dart
+++ b/lib/home/widgets/recipes_screen.dart
@@ -48,13 +48,20 @@ class RecipesScreen extends StatelessWidget {
                                         'Standard Recipe')
                                   {
                                     context.read<RecipeBloc>().add(
-                                        RecipeShowMeasurementsChanged(
-                                            showMeasurements: false,
-                                            recipeIndex: index)),
+                                        const RecipeShowMeasurementsChanged(
+                                            showMeasurements: false)),
                                     context.read<RecipeBloc>().add(
-                                        RecipeShowIngredientsChanged(
-                                            showIngredients: false,
-                                            recipeIndex: index)),
+                                        const RecipeShowIngredientsChanged(
+                                            showIngredients: false)),
+                                  }
+                                else
+                                  {
+                                    context.read<RecipeBloc>().add(
+                                        const RecipeShowMeasurementsChanged(
+                                            showMeasurements: true)),
+                                    context.read<RecipeBloc>().add(
+                                        const RecipeShowIngredientsChanged(
+                                            showIngredients: true)),
                                   },
                                 Navigator.pushNamed(context, PageRouter.recipe,
                                     arguments: (recipeState

--- a/lib/navigation/models/page_router.dart
+++ b/lib/navigation/models/page_router.dart
@@ -34,6 +34,7 @@ class PageRouter {
             routeSettings.arguments as Map<String, dynamic>;
         return _buildRoute(RecipePage(
           args['recipeIndex'],
+          viewedFromCollection: args['viewedFromCollection'],
           assignedFoodItemId: args['assignedFoodItemId'],
           foodItemDescription: args['foodItemDescription'],
           selectedScreen: args['selectedScreen'],

--- a/lib/navigation/models/page_router.dart
+++ b/lib/navigation/models/page_router.dart
@@ -46,8 +46,7 @@ class PageRouter {
       case editProbe:
         Map<String, dynamic> args =
             routeSettings.arguments as Map<String, dynamic>;
-        return _buildRoute(
-            EditProbePage(args['recipeIndex'], args['probeIndex']));
+        return _buildRoute(ProbePage(args['recipeIndex'], args['probeIndex']));
       case sensitizationHelp:
         return _buildRoute(const SensitizationHelpPage());
       case firstPassHelp:

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -41,6 +41,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     on<ProbeOptionSelected>(_onProbeOptionSelected);
     on<RecipeProbesCleared>(_onRecipeProbesCleared);
     on<IngredientAdded>(_onIngredientAdded);
+    on<IngredientDuplicated>(_onIngredientDuplicated);
     on<IngredientDeleted>(_onIngredientDeleted);
     on<IngredientStatusChanged>(_onIngredientStatusChanged);
     on<IngredientNameChanged>(_onIngredientNameChanged);
@@ -518,6 +519,29 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Ingredient> ingredients =
         List.from(recipes[changedRecipeIndex].ingredients);
     ingredients.add(ingredient);
+
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
+
+    recipes.removeAt(changedRecipeIndex);
+    recipes.insert(changedRecipeIndex, recipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onIngredientDuplicated(
+      IngredientDuplicated event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
+    int changedIngredientIndex = ingredients.indexOf(event.ingredient);
+
+    Ingredient ingredient = ingredients[changedIngredientIndex]
+        .copyWith(id: const Uuid().v4(), saved: false);
+
+    ingredients.insert(changedIngredientIndex + 1, ingredient);
 
     Recipe recipe = recipes[changedRecipeIndex]
         .copyWith(ingredients: ingredients, date: _getCurrentDate());

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -21,6 +21,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
       : _gibsonifyRepository = gibsonifyRepository,
         super(const RecipeState()) {
     on<RecipeAdded>(_onRecipeAdded);
+    on<RecipeDuplicated>(_onRecipeDuplicated);
     on<RecipeDeleted>(_onRecipeDeleted);
     on<RecipeNameChanged>(_recipeNameChanged);
     on<RecipeMeasurementAdded>(_onRecipeMeasurementAdded);
@@ -63,6 +64,19 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     List<Recipe> recipes = List.from(state.recipes);
     recipes.add(recipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onRecipeDuplicated(RecipeDuplicated event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    Recipe duplicatedRecipe = recipes[changedRecipeIndex]
+        .copyWith(number: const Uuid().v4(), saved: false);
+
+    recipes.insert(changedRecipeIndex + 1, duplicatedRecipe);
 
     emit(state.copyWith(recipes: recipes));
   }

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -31,6 +31,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     on<RecipeMeasurementUnitChanged>(_onRecipeMeasurementUnitChanged);
     on<RecipeMeasurementValueChanged>(_onRecipeMeasurementValueChanged);
     on<RecipeStatusChanged>(_onRecipeStatusChanged);
+    on<RecipeShowMeasurementsChanged>(_onRecipeShowMeasurementsChanged);
+    on<RecipeShowIngredientsChanged>(_onRecipeShowIngredientsChanged);
     on<ProbeAdded>(_onProbeAdded);
     on<ProbeDuplicated>(_onProbeDuplicated);
     on<ProbeChanged>(_onProbeChanged);
@@ -253,6 +255,46 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     Recipe recipe = recipes[changedRecipeIndex]
         .copyWith(saved: event.recipeSaved, date: _getCurrentDate());
 
+    recipes.removeAt(changedRecipeIndex);
+    recipes.insert(changedRecipeIndex, recipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onRecipeShowMeasurementsChanged(
+      RecipeShowMeasurementsChanged event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    bool newStatus = true;
+    if (event.setShowMeasurements == 'Toggle') {
+      newStatus = !recipes[changedRecipeIndex].showMeasurements;
+    } else if (event.setShowMeasurements == 'False') {
+      newStatus = false;
+    }
+
+    Recipe recipe =
+        recipes[changedRecipeIndex].copyWith(showMeasurements: newStatus);
+    recipes.removeAt(changedRecipeIndex);
+    recipes.insert(changedRecipeIndex, recipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onRecipeShowIngredientsChanged(
+      RecipeShowIngredientsChanged event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    bool newStatus = true;
+    if (event.setShowIngredients == 'Toggle') {
+      newStatus = !recipes[changedRecipeIndex].showMeasurements;
+    } else if (event.setShowIngredients == 'False') {
+      newStatus = false;
+    }
+
+    Recipe recipe =
+        recipes[changedRecipeIndex].copyWith(showIngredients: newStatus);
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
 

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -32,6 +32,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     on<RecipeMeasurementValueChanged>(_onRecipeMeasurementValueChanged);
     on<RecipeStatusChanged>(_onRecipeStatusChanged);
     on<ProbeAdded>(_onProbeAdded);
+    on<ProbeDuplicated>(_onProbeDuplicated);
     on<ProbeChanged>(_onProbeChanged);
     on<ProbeChecked>(_onProbeChecked);
     on<ProbeDeleted>(_onProbeDeleted);
@@ -288,6 +289,26 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     recipes.removeAt(changedRecipeIndex);
 
     recipes.insert(changedRecipeIndex, recipe);
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onProbeDuplicated(ProbeDuplicated event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    List<Probe> probes = List.from(recipes[changedRecipeIndex].probes);
+    int changedProbeIndex = probes.indexOf(event.probe);
+
+    Probe probe = probes[changedProbeIndex].copyWith(id: const Uuid().v4());
+
+    probes.insert(changedProbeIndex + 1, probe);
+
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(probes: probes, date: _getCurrentDate());
+
+    recipes.removeAt(changedRecipeIndex);
+    recipes.insert(changedRecipeIndex, recipe);
+
     emit(state.copyWith(recipes: recipes));
   }
 

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -266,28 +266,12 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
   void _onRecipeShowMeasurementsChanged(
       RecipeShowMeasurementsChanged event, Emitter<RecipeState> emit) {
-    List<Recipe> recipes = List.from(state.recipes);
-    int changedRecipeIndex = event.recipeIndex;
-
-    Recipe recipe = recipes[changedRecipeIndex]
-        .copyWith(showMeasurements: event.showMeasurements);
-    recipes.removeAt(changedRecipeIndex);
-    recipes.insert(changedRecipeIndex, recipe);
-
-    emit(state.copyWith(recipes: recipes));
+    emit(state.copyWith(showMeasurements: event.showMeasurements));
   }
 
   void _onRecipeShowIngredientsChanged(
       RecipeShowIngredientsChanged event, Emitter<RecipeState> emit) {
-    List<Recipe> recipes = List.from(state.recipes);
-    int changedRecipeIndex = event.recipeIndex;
-
-    Recipe recipe = recipes[changedRecipeIndex]
-        .copyWith(showIngredients: event.showIngredients);
-    recipes.removeAt(changedRecipeIndex);
-    recipes.insert(changedRecipeIndex, recipe);
-
-    emit(state.copyWith(recipes: recipes));
+    emit(state.copyWith(showIngredients: event.showIngredients));
   }
 
   bool _areAllProbesChecked(List<Probe> probes) {

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -288,7 +288,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     bool newStatus = true;
     if (event.setShowIngredients == 'Toggle') {
-      newStatus = !recipes[changedRecipeIndex].showMeasurements;
+      newStatus = !recipes[changedRecipeIndex].showIngredients;
     } else if (event.setShowIngredients == 'False') {
       newStatus = false;
     }

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -22,7 +22,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
         super(const RecipeState()) {
     on<RecipeAdded>(_onRecipeAdded);
     on<RecipeDuplicated>(_onRecipeDuplicated);
-    on<RecipeModified>(_onRecipeModified);
+    on<ModifiedRecipeCreated>(_onModifiedRecipeCreated);
     on<RecipeDeleted>(_onRecipeDeleted);
     on<RecipeNameChanged>(_recipeNameChanged);
     on<RecipeMeasurementAdded>(_onRecipeMeasurementAdded);
@@ -95,7 +95,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     emit(state.copyWith(recipes: recipes));
   }
 
-  void _onRecipeModified(RecipeModified event, Emitter<RecipeState> emit) {
+  void _onModifiedRecipeCreated(
+      ModifiedRecipeCreated event, Emitter<RecipeState> emit) {
     List<Recipe> recipes = List.from(state.recipes);
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -248,8 +248,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
-    Recipe recipe =
-        recipes[changedRecipeIndex].copyWith(saved: event.recipeSaved);
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(saved: event.recipeSaved, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -512,7 +512,6 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
   void _onIngredientAdded(IngredientAdded event, Emitter<RecipeState> emit) {
     List<Recipe> recipes = List.from(state.recipes);
-    Recipe standardRecipe = event.recipe;
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
     final ingredient = Ingredient();
@@ -520,32 +519,18 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
         List.from(recipes[changedRecipeIndex].ingredients);
     ingredients.add(ingredient);
 
-    Recipe recipe =
-        (event.recipe.saved == true && event.recipe.type == "Standard Recipe")
-            ? recipes[changedRecipeIndex].copyWith(
-                ingredients: ingredients,
-                saved: false,
-                type: "Modified Recipe",
-                number: const Uuid().v4(),
-                date: _getCurrentDate())
-            : recipes[changedRecipeIndex].copyWith(
-                ingredients: ingredients,
-                saved: false,
-                date: _getCurrentDate());
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
-
-    if (event.recipe.saved == true && event.recipe.type == "Standard Recipe") {
-      recipes.insert(changedRecipeIndex, standardRecipe);
-    }
     recipes.insert(changedRecipeIndex, recipe);
+
     emit(state.copyWith(recipes: recipes));
   }
 
   void _onIngredientDeleted(
       IngredientDeleted event, Emitter<RecipeState> emit) {
     List<Recipe> recipes = List.from(state.recipes);
-    Recipe standardRecipe = event.recipe;
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
     List<Ingredient> ingredients =
@@ -553,25 +538,12 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     int changedIngredientIndex = ingredients.indexOf(event.ingredient);
     ingredients.removeAt(changedIngredientIndex);
 
-    Recipe recipe =
-        (event.recipe.saved == true && event.recipe.type == "Standard Recipe")
-            ? recipes[changedRecipeIndex].copyWith(
-                ingredients: ingredients,
-                saved: false,
-                type: "Modified Recipe",
-                number: const Uuid().v4(),
-                date: _getCurrentDate())
-            : recipes[changedRecipeIndex].copyWith(
-                ingredients: ingredients,
-                saved: false,
-                date: _getCurrentDate());
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
-
-    if (event.recipe.saved == true && event.recipe.type == "Standard Recipe") {
-      recipes.insert(changedRecipeIndex, standardRecipe);
-    }
     recipes.insert(changedRecipeIndex, recipe);
+
     emit(state.copyWith(recipes: recipes));
   }
 
@@ -591,7 +563,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     ingredients.insert(changedIngredientIndex, ingredient);
 
     Recipe recipe = recipes[changedRecipeIndex]
-        .copyWith(ingredients: ingredients, saved: false);
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -619,8 +591,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
 
-    Recipe recipe = recipes[changedRecipeIndex].copyWith(
-        ingredients: ingredients, saved: false, date: _getCurrentDate());
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -643,8 +615,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
 
-    Recipe recipe = recipes[changedRecipeIndex].copyWith(
-        ingredients: ingredients, saved: false, date: _getCurrentDate());
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -667,8 +639,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
 
-    Recipe recipe = recipes[changedRecipeIndex].copyWith(
-        ingredients: ingredients, saved: false, date: _getCurrentDate());
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -691,8 +663,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
 
-    Recipe recipe = recipes[changedRecipeIndex].copyWith(
-        ingredients: ingredients, saved: false, date: _getCurrentDate());
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
 
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
@@ -717,7 +689,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     measurements.add(measurement);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
-        .copyWith(measurements: measurements);
+        .copyWith(measurements: measurements, saved: false);
 
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
@@ -748,7 +720,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     measurements.removeAt(changedmeasurementIndex);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
-        .copyWith(measurements: measurements);
+        .copyWith(measurements: measurements, saved: false);
 
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
@@ -783,7 +755,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     measurements.insert(changedmeasurementIndex, measurement);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
-        .copyWith(measurements: measurements);
+        .copyWith(measurements: measurements, saved: false);
 
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
@@ -818,7 +790,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     measurements.insert(changedmeasurementIndex, measurement);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
-        .copyWith(measurements: measurements);
+        .copyWith(measurements: measurements, saved: false);
 
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
@@ -853,7 +825,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     measurements.insert(changedmeasurementIndex, measurement);
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
-        .copyWith(measurements: measurements);
+        .copyWith(measurements: measurements, saved: false);
 
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);
@@ -918,7 +890,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
       return;
     }
     final input = File(result.files.single.path!).openRead();
-    var lineEndSetting = FirstOccurrenceSettingsDetector(eols: ['\r\n', '\n']);
+    var lineEndSetting =
+        const FirstOccurrenceSettingsDetector(eols: ['\r\n', '\n']);
 
     List data = await input
         .transform(utf8.decoder)

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -264,17 +264,10 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
   void _onRecipeShowMeasurementsChanged(
       RecipeShowMeasurementsChanged event, Emitter<RecipeState> emit) {
     List<Recipe> recipes = List.from(state.recipes);
-    int changedRecipeIndex = recipes.indexOf(event.recipe);
+    int changedRecipeIndex = event.recipeIndex;
 
-    bool newStatus = true;
-    if (event.setShowMeasurements == 'Toggle') {
-      newStatus = !recipes[changedRecipeIndex].showMeasurements;
-    } else if (event.setShowMeasurements == 'False') {
-      newStatus = false;
-    }
-
-    Recipe recipe =
-        recipes[changedRecipeIndex].copyWith(showMeasurements: newStatus);
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(showMeasurements: event.showMeasurements);
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
 
@@ -284,17 +277,10 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
   void _onRecipeShowIngredientsChanged(
       RecipeShowIngredientsChanged event, Emitter<RecipeState> emit) {
     List<Recipe> recipes = List.from(state.recipes);
-    int changedRecipeIndex = recipes.indexOf(event.recipe);
+    int changedRecipeIndex = event.recipeIndex;
 
-    bool newStatus = true;
-    if (event.setShowIngredients == 'Toggle') {
-      newStatus = !recipes[changedRecipeIndex].showIngredients;
-    } else if (event.setShowIngredients == 'False') {
-      newStatus = false;
-    }
-
-    Recipe recipe =
-        recipes[changedRecipeIndex].copyWith(showIngredients: newStatus);
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(showIngredients: event.showIngredients);
     recipes.removeAt(changedRecipeIndex);
     recipes.insert(changedRecipeIndex, recipe);
 

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -51,6 +51,8 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     on<IngredientCustomNameChanged>(_onIngredientCustomNameChanged);
     on<IngredientDescriptionChanged>(_onIngredientDescriptionChanged);
     on<IngredientCookingStateChanged>(_onIngredientCookingStateChanged);
+    on<IngredientCustomCookingStateChanged>(
+        _onIngredientCustomCookingStateChanged);
     on<IngredientMeasurementAdded>(_onIngredientMeasurementAdded);
     on<IngredientMeasurementDeleted>(_onIngredientMeasurementDeleted);
     on<IngredientMeasurementMethodChanged>(
@@ -731,6 +733,30 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     Ingredient ingredient = ingredients[changedIngredientIndex]
         .copyWith(cookingState: event.cookingState, saved: false);
+
+    ingredients.removeAt(changedIngredientIndex);
+    ingredients.insert(changedIngredientIndex, ingredient);
+
+    Recipe recipe = recipes[changedRecipeIndex]
+        .copyWith(ingredients: ingredients, date: _getCurrentDate());
+
+    recipes.removeAt(changedRecipeIndex);
+    recipes.insert(changedRecipeIndex, recipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onIngredientCustomCookingStateChanged(
+      IngredientCustomCookingStateChanged event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+    List<Ingredient> ingredients =
+        List.from(recipes[changedRecipeIndex].ingredients);
+    int changedIngredientIndex = ingredients.indexOf(event.ingredient);
+
+    Ingredient ingredient = ingredients[changedIngredientIndex]
+        .copyWith(customCookingState: event.customCookingState, saved: false);
 
     ingredients.removeAt(changedIngredientIndex);
     ingredients.insert(changedIngredientIndex, ingredient);

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -22,6 +22,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
         super(const RecipeState()) {
     on<RecipeAdded>(_onRecipeAdded);
     on<RecipeDuplicated>(_onRecipeDuplicated);
+    on<RecipeModified>(_onRecipeModified);
     on<RecipeDeleted>(_onRecipeDeleted);
     on<RecipeNameChanged>(_recipeNameChanged);
     on<RecipeMeasurementAdded>(_onRecipeMeasurementAdded);
@@ -58,6 +59,10 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     on<RecipesImported>(_onRecipesImported);
   }
 
+  String _getCurrentDate() {
+    return DateFormat('yyyy-MM-dd').format(DateTime.now());
+  }
+
   void _onRecipeAdded(RecipeAdded event, Emitter<RecipeState> emit) {
     final recipe =
         Recipe(employeeNumber: event.employeeNumber, type: event.type);
@@ -73,10 +78,30 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
 
     int changedRecipeIndex = recipes.indexOf(event.recipe);
 
-    Recipe duplicatedRecipe = recipes[changedRecipeIndex]
-        .copyWith(number: const Uuid().v4(), saved: false);
+    Recipe duplicatedRecipe = recipes[changedRecipeIndex].copyWith(
+        employeeNumber: event.employeeNumber,
+        number: const Uuid().v4(),
+        saved: false,
+        date: _getCurrentDate());
 
     recipes.insert(changedRecipeIndex + 1, duplicatedRecipe);
+
+    emit(state.copyWith(recipes: recipes));
+  }
+
+  void _onRecipeModified(RecipeModified event, Emitter<RecipeState> emit) {
+    List<Recipe> recipes = List.from(state.recipes);
+
+    int changedRecipeIndex = recipes.indexOf(event.recipe);
+
+    Recipe modifiedRecipe = recipes[changedRecipeIndex].copyWith(
+        employeeNumber: event.employeeNumber,
+        type: "Modified Recipe",
+        number: const Uuid().v4(),
+        saved: false,
+        date: _getCurrentDate());
+
+    recipes.insert(changedRecipeIndex + 1, modifiedRecipe);
 
     emit(state.copyWith(recipes: recipes));
   }
@@ -89,10 +114,6 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     recipes.removeAt(changedRecipeIndex);
 
     emit(state.copyWith(recipes: recipes));
-  }
-
-  String _getCurrentDate() {
-    return DateFormat('yyyy-MM-dd').format(DateTime.now());
   }
 
   void _recipeNameChanged(RecipeNameChanged event, Emitter<RecipeState> emit) {

--- a/lib/recipe/bloc/recipe_bloc.dart
+++ b/lib/recipe/bloc/recipe_bloc.dart
@@ -319,8 +319,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
     List<Probe> probes = List.from(recipes[changedRecipeIndex].probes);
     int changedProbeIndex = event.probeIndex;
 
-    Probe probe =
-        probes[changedProbeIndex].copyWith(probeName: event.probeName);
+    Probe probe = probes[changedProbeIndex].copyWith(name: event.probeName);
 
     probes.removeAt(changedProbeIndex);
     probes.insert(changedProbeIndex, probe);
@@ -1023,8 +1022,7 @@ class RecipeBloc extends Bloc<RecipeEvent, RecipeState> {
         for (String answer in probeAnswers) {
           probeOptions.add({'option': answer.trim(), 'id': const Uuid().v4()});
         }
-        final probe =
-            Probe(probeName: recipeProbeName, probeOptions: probeOptions);
+        final probe = Probe(name: recipeProbeName, probeOptions: probeOptions);
         probes.add(probe);
 
         recipe = recipe.copyWith(probes: probes);

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -27,11 +27,12 @@ class RecipeDuplicated extends RecipeEvent {
   List<Object> get props => [recipe, employeeNumber];
 }
 
-class RecipeModified extends RecipeEvent {
+class ModifiedRecipeCreated extends RecipeEvent {
   final Recipe recipe;
   final String employeeNumber;
 
-  const RecipeModified({required this.recipe, required this.employeeNumber});
+  const ModifiedRecipeCreated(
+      {required this.recipe, required this.employeeNumber});
 
   @override
   List<Object> get props => [recipe, employeeNumber];

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -368,6 +368,20 @@ class IngredientCookingStateChanged extends RecipeEvent {
   List<Object> get props => [cookingState, ingredient, recipe];
 }
 
+class IngredientCustomCookingStateChanged extends RecipeEvent {
+  final String customCookingState;
+  final Ingredient ingredient;
+  final Recipe recipe;
+
+  const IngredientCustomCookingStateChanged(
+      {required this.customCookingState,
+      required this.ingredient,
+      required this.recipe});
+
+  @override
+  List<Object> get props => [customCookingState, ingredient, recipe];
+}
+
 class IngredientMeasurementAdded extends RecipeEvent {
   final Recipe recipe;
   final Ingredient ingredient;

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -19,11 +19,22 @@ class RecipeAdded extends RecipeEvent {
 
 class RecipeDuplicated extends RecipeEvent {
   final Recipe recipe;
+  final String employeeNumber;
 
-  const RecipeDuplicated({required this.recipe});
+  const RecipeDuplicated({required this.recipe, required this.employeeNumber});
 
   @override
-  List<Object> get props => [recipe];
+  List<Object> get props => [recipe, employeeNumber];
+}
+
+class RecipeModified extends RecipeEvent {
+  final Recipe recipe;
+  final String employeeNumber;
+
+  const RecipeModified({required this.recipe, required this.employeeNumber});
+
+  @override
+  List<Object> get props => [recipe, employeeNumber];
 }
 
 class RecipeDeleted extends RecipeEvent {

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -246,6 +246,16 @@ class IngredientAdded extends RecipeEvent {
   List<Object> get props => [recipe];
 }
 
+class IngredientDuplicated extends RecipeEvent {
+  final Recipe recipe;
+  final Ingredient ingredient;
+
+  const IngredientDuplicated({required this.recipe, required this.ingredient});
+
+  @override
+  List<Object> get props => [recipe, ingredient];
+}
+
 class IngredientDeleted extends RecipeEvent {
   final Recipe recipe;
   final Ingredient ingredient;

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -129,25 +129,25 @@ class RecipeStatusChanged extends RecipeEvent {
 }
 
 class RecipeShowMeasurementsChanged extends RecipeEvent {
-  final String setShowMeasurements;
-  final Recipe recipe;
+  final bool showMeasurements;
+  final int recipeIndex;
 
   const RecipeShowMeasurementsChanged(
-      {required this.setShowMeasurements, required this.recipe});
+      {required this.showMeasurements, required this.recipeIndex});
 
   @override
-  List<Object> get props => [setShowMeasurements, recipe];
+  List<Object> get props => [showMeasurements, recipeIndex];
 }
 
 class RecipeShowIngredientsChanged extends RecipeEvent {
-  final String setShowIngredients;
-  final Recipe recipe;
+  final bool showIngredients;
+  final int recipeIndex;
 
   const RecipeShowIngredientsChanged(
-      {required this.setShowIngredients, required this.recipe});
+      {required this.showIngredients, required this.recipeIndex});
 
   @override
-  List<Object> get props => [setShowIngredients, recipe];
+  List<Object> get props => [showIngredients, recipeIndex];
 }
 
 class ProbeAdded extends RecipeEvent {

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -128,6 +128,28 @@ class RecipeStatusChanged extends RecipeEvent {
   List<Object> get props => [recipeSaved, recipe];
 }
 
+class RecipeShowMeasurementsChanged extends RecipeEvent {
+  final String setShowMeasurements;
+  final Recipe recipe;
+
+  const RecipeShowMeasurementsChanged(
+      {required this.setShowMeasurements, required this.recipe});
+
+  @override
+  List<Object> get props => [setShowMeasurements, recipe];
+}
+
+class RecipeShowIngredientsChanged extends RecipeEvent {
+  final String setShowIngredients;
+  final Recipe recipe;
+
+  const RecipeShowIngredientsChanged(
+      {required this.setShowIngredients, required this.recipe});
+
+  @override
+  List<Object> get props => [setShowIngredients, recipe];
+}
+
 class ProbeAdded extends RecipeEvent {
   final Recipe recipe;
 

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -137,6 +137,16 @@ class ProbeAdded extends RecipeEvent {
   List<Object> get props => [recipe];
 }
 
+class ProbeDuplicated extends RecipeEvent {
+  final Recipe recipe;
+  final Probe probe;
+
+  const ProbeDuplicated({required this.recipe, required this.probe});
+
+  @override
+  List<Object> get props => [recipe, probe];
+}
+
 class ProbeChanged extends RecipeEvent {
   final Recipe recipe;
   final String probeName;

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -17,6 +17,15 @@ class RecipeAdded extends RecipeEvent {
   List<Object> get props => [employeeNumber, type];
 }
 
+class RecipeDuplicated extends RecipeEvent {
+  final Recipe recipe;
+
+  const RecipeDuplicated({required this.recipe});
+
+  @override
+  List<Object> get props => [recipe];
+}
+
 class RecipeDeleted extends RecipeEvent {
   final Recipe recipe;
 

--- a/lib/recipe/bloc/recipe_event.dart
+++ b/lib/recipe/bloc/recipe_event.dart
@@ -131,24 +131,20 @@ class RecipeStatusChanged extends RecipeEvent {
 
 class RecipeShowMeasurementsChanged extends RecipeEvent {
   final bool showMeasurements;
-  final int recipeIndex;
 
-  const RecipeShowMeasurementsChanged(
-      {required this.showMeasurements, required this.recipeIndex});
+  const RecipeShowMeasurementsChanged({required this.showMeasurements});
 
   @override
-  List<Object> get props => [showMeasurements, recipeIndex];
+  List<Object> get props => [showMeasurements];
 }
 
 class RecipeShowIngredientsChanged extends RecipeEvent {
   final bool showIngredients;
-  final int recipeIndex;
 
-  const RecipeShowIngredientsChanged(
-      {required this.showIngredients, required this.recipeIndex});
+  const RecipeShowIngredientsChanged({required this.showIngredients});
 
   @override
-  List<Object> get props => [showIngredients, recipeIndex];
+  List<Object> get props => [showIngredients];
 }
 
 class ProbeAdded extends RecipeEvent {

--- a/lib/recipe/bloc/recipe_state.dart
+++ b/lib/recipe/bloc/recipe_state.dart
@@ -4,20 +4,28 @@ class RecipeState extends Equatable {
   final List<Recipe> recipes;
   final String? ingredientsJson;
   final String? recipeImportStatus;
+  final bool showMeasurements;
+  final bool showIngredients;
 
   const RecipeState(
       {this.recipes = const <Recipe>[],
       this.ingredientsJson,
-      this.recipeImportStatus});
+      this.recipeImportStatus,
+      this.showMeasurements = true,
+      this.showIngredients = true});
 
   RecipeState copyWith(
       {List<Recipe>? recipes,
       String? ingredientsJson,
-      String? recipeImportStatus}) {
+      String? recipeImportStatus,
+      bool? showMeasurements,
+      bool? showIngredients}) {
     return RecipeState(
         recipes: recipes ?? this.recipes,
         ingredientsJson: ingredientsJson ?? this.ingredientsJson,
-        recipeImportStatus: recipeImportStatus ?? this.recipeImportStatus);
+        recipeImportStatus: recipeImportStatus ?? this.recipeImportStatus,
+        showMeasurements: showMeasurements ?? this.showMeasurements,
+        showIngredients: showIngredients ?? this.showIngredients);
   }
 
   @override
@@ -25,5 +33,7 @@ class RecipeState extends Equatable {
         recipes,
         ingredientsJson,
         recipeImportStatus,
+        showMeasurements,
+        showIngredients
       ];
 }

--- a/lib/recipe/view/edit_probe_page.dart
+++ b/lib/recipe/view/edit_probe_page.dart
@@ -12,29 +12,32 @@ class EditProbePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
       return Scaffold(
-          appBar: AppBar(title: const Text('Edit Probe')),
-          floatingActionButton: Column(
-              mainAxisAlignment: MainAxisAlignment.end,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: <Widget>[
-                FloatingActionButton.extended(
-                    heroTag: null,
-                    label: const Text("Add probe response"),
-                    icon: const Icon(Icons.add),
-                    onPressed: () => {
-                          context.read<RecipeBloc>().add(ProbeOptionAdded(
-                              recipe: state.recipes[recipeIndex],
-                              probeIndex: probeIndex)),
-                        }),
-                const SizedBox(
-                  height: 10,
-                ),
-                FloatingActionButton.extended(
-                    heroTag: null,
-                    label: const Text("Save Probe"),
-                    icon: const Icon(Icons.save_sharp),
-                    onPressed: () => {Navigator.pop(context)})
-              ]),
+          appBar: AppBar(title: const Text('View Probe')),
+          floatingActionButton: Visibility(
+            visible: !state.recipes[recipeIndex].saved,
+            child: Column(
+                mainAxisAlignment: MainAxisAlignment.end,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  FloatingActionButton.extended(
+                      heroTag: null,
+                      label: const Text("Add probe response"),
+                      icon: const Icon(Icons.add),
+                      onPressed: () => {
+                            context.read<RecipeBloc>().add(ProbeOptionAdded(
+                                recipe: state.recipes[recipeIndex],
+                                probeIndex: probeIndex)),
+                          }),
+                  const SizedBox(
+                    height: 10,
+                  ),
+                  FloatingActionButton.extended(
+                      heroTag: null,
+                      label: const Text("Save Probe"),
+                      icon: const Icon(Icons.save_sharp),
+                      onPressed: () => {Navigator.pop(context)})
+                ]),
+          ),
           body: ProbeForm(recipeIndex, probeIndex));
     });
   }

--- a/lib/recipe/view/ingredient_page.dart
+++ b/lib/recipe/view/ingredient_page.dart
@@ -19,12 +19,26 @@ class IngredientPage extends StatelessWidget {
                 label: const Text("Save"),
                 icon: const Icon(Icons.save_sharp),
                 onPressed: () => {
-                      context.read<RecipeBloc>().add(IngredientStatusChanged(
-                          recipe: state.recipes[recipeIndex],
-                          ingredient: state.recipes[recipeIndex]
-                              .ingredients[ingredientIndex],
-                          ingredientSaved: true)),
-                      Navigator.pop(context)
+                      if (state
+                              .recipes[recipeIndex].ingredients[ingredientIndex]
+                              .areMeasurementsFilled() ||
+                          state.recipes[recipeIndex].type == 'Standard Recipe')
+                        {
+                          context.read<RecipeBloc>().add(
+                              IngredientStatusChanged(
+                                  recipe: state.recipes[recipeIndex],
+                                  ingredient: state.recipes[recipeIndex]
+                                      .ingredients[ingredientIndex],
+                                  ingredientSaved: true)),
+                          Navigator.pop(context)
+                        }
+                      else
+                        {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                  content:
+                                      Text('Each measurement must be filled')))
+                        }
                     }),
           ),
           body: IngredientForm(recipeIndex, ingredientIndex));

--- a/lib/recipe/view/ingredient_page.dart
+++ b/lib/recipe/view/ingredient_page.dart
@@ -12,18 +12,21 @@ class IngredientPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
       return Scaffold(
-          appBar: AppBar(title: const Text('Edit Ingredient')),
-          floatingActionButton: FloatingActionButton.extended(
-              label: const Text("Save"),
-              icon: const Icon(Icons.save_sharp),
-              onPressed: () => {
-                    context.read<RecipeBloc>().add(IngredientStatusChanged(
-                        recipe: state.recipes[recipeIndex],
-                        ingredient: state
-                            .recipes[recipeIndex].ingredients[ingredientIndex],
-                        ingredientSaved: true)),
-                    Navigator.pop(context)
-                  }),
+          appBar: AppBar(title: const Text('View Ingredient')),
+          floatingActionButton: Visibility(
+            visible: !state.recipes[recipeIndex].saved,
+            child: FloatingActionButton.extended(
+                label: const Text("Save"),
+                icon: const Icon(Icons.save_sharp),
+                onPressed: () => {
+                      context.read<RecipeBloc>().add(IngredientStatusChanged(
+                          recipe: state.recipes[recipeIndex],
+                          ingredient: state.recipes[recipeIndex]
+                              .ingredients[ingredientIndex],
+                          ingredientSaved: true)),
+                      Navigator.pop(context)
+                    }),
+          ),
           body: IngredientForm(recipeIndex, ingredientIndex));
     });
   }

--- a/lib/recipe/view/probe_page.dart
+++ b/lib/recipe/view/probe_page.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gibsonify/recipe/recipe.dart';
 
-class EditProbePage extends StatelessWidget {
+class ProbePage extends StatelessWidget {
   final int recipeIndex;
   final int probeIndex;
-  const EditProbePage(this.recipeIndex, this.probeIndex, {Key? key})
+  const ProbePage(this.recipeIndex, this.probeIndex, {Key? key})
       : super(key: key);
 
   @override

--- a/lib/recipe/view/recipe_page.dart
+++ b/lib/recipe/view/recipe_page.dart
@@ -11,12 +11,14 @@ enum SelectedRecipeScreen {
 
 class RecipePage extends StatefulWidget {
   final int recipeIndex;
+  final bool viewedFromCollection;
   final String? assignedFoodItemId;
   final String? foodItemDescription;
   final SelectedRecipeScreen? selectedScreen;
 
   const RecipePage(this.recipeIndex,
       {Key? key,
+      required this.viewedFromCollection,
       this.assignedFoodItemId,
       this.foodItemDescription,
       this.selectedScreen})
@@ -47,11 +49,12 @@ class _RecipePageState extends State<RecipePage> {
   Widget build(BuildContext context) {
     final List<Widget> _screens = [
       RecipeProbesScreen(widget.recipeIndex,
+          viewedFromCollection: widget.viewedFromCollection,
           assignedFoodItemId: widget.assignedFoodItemId,
           foodItemDescription: widget.foodItemDescription),
-      RecipeIngredientsScreen(widget.recipeIndex,
-          assignedFoodItemId: widget.assignedFoodItemId),
+      RecipeIngredientsScreen(widget.recipeIndex),
       RecipeDetailsScreen(widget.recipeIndex,
+          viewedFromCollection: widget.viewedFromCollection,
           assignedFoodItemId: widget.assignedFoodItemId),
     ];
 

--- a/lib/recipe/view/view.dart
+++ b/lib/recipe/view/view.dart
@@ -1,3 +1,3 @@
 export 'recipe_page.dart';
 export 'ingredient_page.dart';
-export 'edit_probe_page.dart';
+export 'probe_page.dart';

--- a/lib/recipe/widgets/ingredient_form.dart
+++ b/lib/recipe/widgets/ingredient_form.dart
@@ -172,6 +172,7 @@ class IngredientMeasurements extends StatelessWidget {
               return Slidable(
                 key: Key(state.recipes[recipeIndex].ingredients[ingredientIndex]
                     .measurements[index].id),
+                enabled: !state.recipes[recipeIndex].saved,
                 endActionPane: ActionPane(
                   motion: const ScrollMotion(),
                   children: [

--- a/lib/recipe/widgets/ingredient_form.dart
+++ b/lib/recipe/widgets/ingredient_form.dart
@@ -97,13 +97,8 @@ class IngredientForm extends StatelessWidget {
                 icon: const Icon(Icons.description_rounded),
                 labelText: 'Ingredient description',
                 helperText: 'Ingredient description e.g. Big, dry, ripe etc.',
-                // TODO: Refactor the error condition into a reusable method
-                errorText: (state.recipes[recipeIndex]
-                                .ingredients[ingredientIndex].description !=
-                            null &&
-                        state.recipes[recipeIndex].ingredients[ingredientIndex]
-                                .description ==
-                            '')
+                errorText: (isFieldModifiedAndEmpty(state.recipes[recipeIndex]
+                        .ingredients[ingredientIndex].description))
                     ? 'Enter an ingredient description e.g. Ripe'
                     : null,
               ),

--- a/lib/recipe/widgets/ingredient_form.dart
+++ b/lib/recipe/widgets/ingredient_form.dart
@@ -28,7 +28,7 @@ class IngredientForm extends StatelessWidget {
     "Boiled and stir-fried",
     "Steamed and fried",
     "Roasted and boiled",
-    "Other"
+    "Other (please specify)"
   ];
 
   @override
@@ -69,8 +69,6 @@ class IngredientForm extends StatelessWidget {
                     visible: (state.recipes[recipeIndex]
                             .ingredients[ingredientIndex].name ==
                         "Other (please specify)"),
-                    // TODO: Implement a better implementation for this check
-                    // possibly a flag to show customName is chosen
                     child: TextFormField(
                       initialValue: state.recipes[recipeIndex]
                           .ingredients[ingredientIndex].customName,
@@ -141,6 +139,35 @@ class IngredientForm extends StatelessWidget {
                               recipe: state.recipes[recipeIndex])),
                       selectedItem: state.recipes[recipeIndex]
                           .ingredients[ingredientIndex].cookingState),
+                  Visibility(
+                    visible: (state.recipes[recipeIndex]
+                            .ingredients[ingredientIndex].cookingState ==
+                        "Other (please specify)"),
+                    child: TextFormField(
+                      initialValue: state.recipes[recipeIndex]
+                          .ingredients[ingredientIndex].customCookingState,
+                      decoration: InputDecoration(
+                        icon: const Icon(Icons.set_meal_rounded),
+                        labelText: 'Specify cooking state',
+                        helperText: 'Cooking state e.g. Barbequed',
+                        errorText: (state.recipes[recipeIndex]
+                                    .ingredients[ingredientIndex].customName ==
+                                null)
+                            ? 'Enter a cooking state e.g. Barbequed'
+                            : null,
+                      ),
+                      onChanged: (value) {
+                        context.read<RecipeBloc>().add(
+                            IngredientCustomCookingStateChanged(
+                                ingredient: state.recipes[recipeIndex]
+                                    .ingredients[ingredientIndex],
+                                customCookingState: value,
+                                recipe: state.recipes[recipeIndex]));
+                      },
+                      textInputAction: TextInputAction.next,
+                      textCapitalization: TextCapitalization.sentences,
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/lib/recipe/widgets/ingredient_form.dart
+++ b/lib/recipe/widgets/ingredient_form.dart
@@ -359,7 +359,7 @@ class DeleteIngredientMeasurementDialog extends StatelessWidget {
         content: const Text('Would you like to delete the measurement?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, 'Cancel'),
+            onPressed: () => Navigator.pop(context),
             child: const Text('Cancel'),
           ),
           TextButton(
@@ -368,7 +368,7 @@ class DeleteIngredientMeasurementDialog extends StatelessWidget {
                   recipe: recipe,
                   ingredient: ingredient,
                   measurementIndex: measurementIndex)),
-              Navigator.pop(context, 'Delete'),
+              Navigator.pop(context),
             },
             child: const Text('Delete'),
           ),

--- a/lib/recipe/widgets/ingredient_form.dart
+++ b/lib/recipe/widgets/ingredient_form.dart
@@ -39,97 +39,111 @@ class IngredientForm extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: [
-            DropdownSearch<String>(
-                dropdownSearchDecoration: const InputDecoration(
-                  icon: Icon(Icons.food_bank_rounded),
-                  labelText: 'Ingredient name',
-                  helperText: 'Ingredient name e.g. Potato',
-                ),
-                mode: Mode.MENU,
-                showSelectedItems: true,
-                showSearchBox: true,
-                enabled: (state.ingredientsJson != null),
-                items: (state.ingredientsJson != null)
-                    ? json.decode(state.ingredientsJson!).keys.toList()
-                    : [],
-                onChanged: (String? answer) => context.read<RecipeBloc>().add(
-                    IngredientNameChanged(
-                        ingredient: state
-                            .recipes[recipeIndex].ingredients[ingredientIndex],
-                        ingredientName: answer!,
-                        recipe: state.recipes[recipeIndex])),
-                selectedItem: state
-                    .recipes[recipeIndex].ingredients[ingredientIndex].name),
-            Visibility(
-              visible: (state
-                      .recipes[recipeIndex].ingredients[ingredientIndex].name ==
-                  "Other (please specify)"),
-              // TODO: Implement a better implementation for this check
-              // possibly a flag to show customName is chosen
-              child: TextFormField(
-                initialValue: state.recipes[recipeIndex]
-                    .ingredients[ingredientIndex].customName,
-                decoration: InputDecoration(
-                  icon: const Icon(Icons.set_meal_rounded),
-                  labelText: 'Specify ingredient',
-                  helperText: 'Ingredient name e.g. Black rice',
-                  errorText: (state.recipes[recipeIndex]
-                              .ingredients[ingredientIndex].customName ==
-                          null)
-                      ? 'Enter an ingredient name e.g. Black rice'
-                      : null,
-                ),
-                onChanged: (value) {
-                  context.read<RecipeBloc>().add(IngredientCustomNameChanged(
-                      ingredient: state
-                          .recipes[recipeIndex].ingredients[ingredientIndex],
-                      ingredientCustomName: value,
-                      recipe: state.recipes[recipeIndex]));
-                },
-                textInputAction: TextInputAction.next,
-                textCapitalization: TextCapitalization.sentences,
+            AbsorbPointer(
+              absorbing: state.recipes[recipeIndex].saved,
+              child: Column(
+                children: [
+                  DropdownSearch<String>(
+                      dropdownSearchDecoration: const InputDecoration(
+                        icon: Icon(Icons.food_bank_rounded),
+                        labelText: 'Ingredient name',
+                        helperText: 'Ingredient name e.g. Potato',
+                      ),
+                      mode: Mode.MENU,
+                      showSelectedItems: true,
+                      showSearchBox: true,
+                      enabled: (state.ingredientsJson != null),
+                      items: (state.ingredientsJson != null)
+                          ? json.decode(state.ingredientsJson!).keys.toList()
+                          : [],
+                      onChanged: (String? answer) => context
+                          .read<RecipeBloc>()
+                          .add(IngredientNameChanged(
+                              ingredient: state.recipes[recipeIndex]
+                                  .ingredients[ingredientIndex],
+                              ingredientName: answer!,
+                              recipe: state.recipes[recipeIndex])),
+                      selectedItem: state.recipes[recipeIndex]
+                          .ingredients[ingredientIndex].name),
+                  Visibility(
+                    visible: (state.recipes[recipeIndex]
+                            .ingredients[ingredientIndex].name ==
+                        "Other (please specify)"),
+                    // TODO: Implement a better implementation for this check
+                    // possibly a flag to show customName is chosen
+                    child: TextFormField(
+                      initialValue: state.recipes[recipeIndex]
+                          .ingredients[ingredientIndex].customName,
+                      decoration: InputDecoration(
+                        icon: const Icon(Icons.set_meal_rounded),
+                        labelText: 'Specify ingredient',
+                        helperText: 'Ingredient name e.g. Black rice',
+                        errorText: (state.recipes[recipeIndex]
+                                    .ingredients[ingredientIndex].customName ==
+                                null)
+                            ? 'Enter an ingredient name e.g. Black rice'
+                            : null,
+                      ),
+                      onChanged: (value) {
+                        context.read<RecipeBloc>().add(
+                            IngredientCustomNameChanged(
+                                ingredient: state.recipes[recipeIndex]
+                                    .ingredients[ingredientIndex],
+                                ingredientCustomName: value,
+                                recipe: state.recipes[recipeIndex]));
+                      },
+                      textInputAction: TextInputAction.next,
+                      textCapitalization: TextCapitalization.sentences,
+                    ),
+                  ),
+                  TextFormField(
+                    initialValue: state.recipes[recipeIndex]
+                        .ingredients[ingredientIndex].description,
+                    decoration: InputDecoration(
+                      icon: const Icon(Icons.description_rounded),
+                      labelText: 'Ingredient description',
+                      helperText:
+                          'Ingredient description e.g. Big, dry, ripe etc.',
+                      errorText: (isFieldModifiedAndEmpty(state
+                              .recipes[recipeIndex]
+                              .ingredients[ingredientIndex]
+                              .description))
+                          ? 'Enter an ingredient description e.g. Ripe'
+                          : null,
+                    ),
+                    onChanged: (value) {
+                      context.read<RecipeBloc>().add(
+                          IngredientDescriptionChanged(
+                              ingredient: state.recipes[recipeIndex]
+                                  .ingredients[ingredientIndex],
+                              ingredientDescription: value,
+                              recipe: state.recipes[recipeIndex]));
+                    },
+                    textCapitalization: TextCapitalization.sentences,
+                    textInputAction: TextInputAction.next,
+                  ),
+                  DropdownSearch<String>(
+                      dropdownSearchDecoration: const InputDecoration(
+                        icon: Icon(Icons.food_bank_rounded),
+                        labelText: "Cooking state",
+                        helperText: 'How the ingredient is prepared',
+                      ),
+                      mode: Mode.MENU,
+                      showSelectedItems: true,
+                      showSearchBox: true,
+                      items: cookingStates,
+                      onChanged: (String? answer) => context
+                          .read<RecipeBloc>()
+                          .add(IngredientCookingStateChanged(
+                              ingredient: state.recipes[recipeIndex]
+                                  .ingredients[ingredientIndex],
+                              cookingState: answer!,
+                              recipe: state.recipes[recipeIndex])),
+                      selectedItem: state.recipes[recipeIndex]
+                          .ingredients[ingredientIndex].cookingState),
+                ],
               ),
             ),
-            TextFormField(
-              initialValue: state.recipes[recipeIndex]
-                  .ingredients[ingredientIndex].description,
-              decoration: InputDecoration(
-                icon: const Icon(Icons.description_rounded),
-                labelText: 'Ingredient description',
-                helperText: 'Ingredient description e.g. Big, dry, ripe etc.',
-                errorText: (isFieldModifiedAndEmpty(state.recipes[recipeIndex]
-                        .ingredients[ingredientIndex].description))
-                    ? 'Enter an ingredient description e.g. Ripe'
-                    : null,
-              ),
-              onChanged: (value) {
-                context.read<RecipeBloc>().add(IngredientDescriptionChanged(
-                    ingredient:
-                        state.recipes[recipeIndex].ingredients[ingredientIndex],
-                    ingredientDescription: value,
-                    recipe: state.recipes[recipeIndex]));
-              },
-              textCapitalization: TextCapitalization.sentences,
-              textInputAction: TextInputAction.next,
-            ),
-            DropdownSearch<String>(
-                dropdownSearchDecoration: const InputDecoration(
-                  icon: Icon(Icons.food_bank_rounded),
-                  labelText: "Cooking state",
-                  helperText: 'How the ingredient is prepared',
-                ),
-                mode: Mode.MENU,
-                showSelectedItems: true,
-                showSearchBox: true,
-                items: cookingStates,
-                onChanged: (String? answer) => context.read<RecipeBloc>().add(
-                    IngredientCookingStateChanged(
-                        ingredient: state
-                            .recipes[recipeIndex].ingredients[ingredientIndex],
-                        cookingState: answer!,
-                        recipe: state.recipes[recipeIndex])),
-                selectedItem: state.recipes[recipeIndex]
-                    .ingredients[ingredientIndex].cookingState),
             const SizedBox(height: 10),
             IngredientMeasurements(recipeIndex, ingredientIndex)
           ],
@@ -190,100 +204,107 @@ class IngredientMeasurements extends StatelessWidget {
                     )
                   ],
                 ),
-                child: Card(
-                    child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Column(
-                    children: [
-                      DropdownSearch<String>(
-                          dropdownSearchDecoration: const InputDecoration(
-                            icon: Icon(Icons.food_bank_rounded),
-                            labelText: "Measurement method",
-                            helperText: 'How the measurement is measured',
-                          ),
-                          mode: Mode.MENU,
-                          showSelectedItems: true,
-                          showSearchBox: true,
-                          items: Measurement.measurementMethods,
-                          onChanged: (String? answer) => context
-                              .read<RecipeBloc>()
-                              .add(IngredientMeasurementMethodChanged(
-                                  measurementIndex: index,
-                                  ingredient: state.recipes[recipeIndex]
-                                      .ingredients[ingredientIndex],
-                                  measurementMethod: answer!,
-                                  recipe: state.recipes[recipeIndex])),
-                          selectedItem: state
+                child: AbsorbPointer(
+                  absorbing: state.recipes[recipeIndex].saved,
+                  child: Card(
+                      child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Column(
+                      children: [
+                        DropdownSearch<String>(
+                            dropdownSearchDecoration: const InputDecoration(
+                              icon: Icon(Icons.food_bank_rounded),
+                              labelText: "Measurement method",
+                              helperText: 'How the measurement is measured',
+                            ),
+                            mode: Mode.MENU,
+                            showSelectedItems: true,
+                            showSearchBox: true,
+                            items: Measurement.measurementMethods,
+                            onChanged: (String? answer) => context
+                                .read<RecipeBloc>()
+                                .add(IngredientMeasurementMethodChanged(
+                                    measurementIndex: index,
+                                    ingredient: state.recipes[recipeIndex]
+                                        .ingredients[ingredientIndex],
+                                    measurementMethod: answer!,
+                                    recipe: state.recipes[recipeIndex])),
+                            selectedItem: state
+                                .recipes[recipeIndex]
+                                .ingredients[ingredientIndex]
+                                .measurements[index]
+                                .measurementMethod),
+                        DropdownSearch<String>(
+                            dropdownSearchDecoration: const InputDecoration(
+                              icon: Icon(Icons.local_dining_rounded),
+                              labelText: "Measurement unit",
+                              helperText: 'The unit of each measurement value',
+                            ),
+                            mode: Mode.MENU,
+                            showSelectedItems: true,
+                            showSearchBox: true,
+                            items: Measurement.measurementUnits,
+                            onChanged: (String? answer) => context
+                                .read<RecipeBloc>()
+                                .add(IngredientMeasurementUnitChanged(
+                                    measurementIndex: index,
+                                    ingredient: state.recipes[recipeIndex]
+                                        .ingredients[ingredientIndex],
+                                    measurementUnit: answer!,
+                                    recipe: state.recipes[recipeIndex])),
+                            selectedItem: state
+                                .recipes[recipeIndex]
+                                .ingredients[ingredientIndex]
+                                .measurements[index]
+                                .measurementUnit),
+                        TextFormField(
+                          initialValue: state
                               .recipes[recipeIndex]
                               .ingredients[ingredientIndex]
                               .measurements[index]
-                              .measurementMethod),
-                      DropdownSearch<String>(
-                          dropdownSearchDecoration: const InputDecoration(
-                            icon: Icon(Icons.local_dining_rounded),
-                            labelText: "Measurement unit",
-                            helperText: 'The unit of each measurement value',
+                              .measurementValue,
+                          decoration: InputDecoration(
+                            icon:
+                                const Icon(Icons.format_list_numbered_rounded),
+                            labelText: 'Measurement value',
+                            helperText: 'Input measurement value',
+                            errorText: !state
+                                    .recipes[recipeIndex]
+                                    .ingredients[ingredientIndex]
+                                    .measurements[index]
+                                    .isValueValid()
+                                ? 'Enter the measured value in 1 to 4 digits'
+                                : null,
                           ),
-                          mode: Mode.MENU,
-                          showSelectedItems: true,
-                          showSearchBox: true,
-                          items: Measurement.measurementUnits,
-                          onChanged: (String? answer) => context
-                              .read<RecipeBloc>()
-                              .add(IngredientMeasurementUnitChanged(
-                                  measurementIndex: index,
-                                  ingredient: state.recipes[recipeIndex]
-                                      .ingredients[ingredientIndex],
-                                  measurementUnit: answer!,
-                                  recipe: state.recipes[recipeIndex])),
-                          selectedItem: state
-                              .recipes[recipeIndex]
-                              .ingredients[ingredientIndex]
-                              .measurements[index]
-                              .measurementUnit),
-                      TextFormField(
-                        initialValue: state
-                            .recipes[recipeIndex]
-                            .ingredients[ingredientIndex]
-                            .measurements[index]
-                            .measurementValue,
-                        decoration: InputDecoration(
-                          icon: const Icon(Icons.format_list_numbered_rounded),
-                          labelText: 'Measurement value',
-                          helperText: 'Input measurement value',
-                          errorText: !state
-                                  .recipes[recipeIndex]
-                                  .ingredients[ingredientIndex]
-                                  .measurements[index]
-                                  .isValueValid()
-                              ? 'Enter the measured value in 1 to 4 digits'
-                              : null,
+                          onChanged: (value) {
+                            context.read<RecipeBloc>().add(
+                                IngredientMeasurementValueChanged(
+                                    measurementIndex: index,
+                                    ingredient: state.recipes[recipeIndex]
+                                        .ingredients[ingredientIndex],
+                                    measurementValue: value,
+                                    recipe: state.recipes[recipeIndex]));
+                          },
+                          textInputAction: TextInputAction.next,
+                          keyboardType: TextInputType.number,
                         ),
-                        onChanged: (value) {
-                          context.read<RecipeBloc>().add(
-                              IngredientMeasurementValueChanged(
-                                  measurementIndex: index,
-                                  ingredient: state.recipes[recipeIndex]
-                                      .ingredients[ingredientIndex],
-                                  measurementValue: value,
-                                  recipe: state.recipes[recipeIndex]));
-                        },
-                        textInputAction: TextInputAction.next,
-                        keyboardType: TextInputType.number,
-                      ),
-                      const Divider(),
-                      ListTile(
-                        title: const Text('Add measurement'),
-                        leading: const Icon(Icons.add),
-                        onTap: () => context.read<RecipeBloc>().add(
-                            IngredientMeasurementAdded(
-                                ingredient: state.recipes[recipeIndex]
-                                    .ingredients[ingredientIndex],
-                                recipe: state.recipes[recipeIndex])),
-                      ),
-                    ],
-                  ),
-                )),
+                        const Divider(),
+                        Visibility(
+                          visible: !state.recipes[recipeIndex].saved,
+                          child: ListTile(
+                            title: const Text('Add measurement'),
+                            leading: const Icon(Icons.add),
+                            onTap: () => context.read<RecipeBloc>().add(
+                                IngredientMeasurementAdded(
+                                    ingredient: state.recipes[recipeIndex]
+                                        .ingredients[ingredientIndex],
+                                    recipe: state.recipes[recipeIndex])),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )),
+                ),
               );
             }),
       );

--- a/lib/recipe/widgets/ingredient_form.dart
+++ b/lib/recipe/widgets/ingredient_form.dart
@@ -37,7 +37,7 @@ class IngredientForm extends StatelessWidget {
       context.read<RecipeBloc>().add(const IngredientsLoaded());
       return Padding(
         padding: const EdgeInsets.all(8.0),
-        child: Column(
+        child: ListView(
           children: [
             AbsorbPointer(
               absorbing: state.recipes[recipeIndex].saved,
@@ -190,152 +190,151 @@ class IngredientMeasurements extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
-      return Expanded(
-        child: ListView.builder(
-            padding: const EdgeInsets.all(2.0),
-            itemCount: state.recipes[recipeIndex].ingredients[ingredientIndex]
-                .measurements.length,
-            itemBuilder: (context, index) {
-              return Slidable(
-                key: Key(state.recipes[recipeIndex].ingredients[ingredientIndex]
-                    .measurements[index].id),
-                enabled: !state.recipes[recipeIndex].saved,
-                endActionPane: ActionPane(
-                  motion: const ScrollMotion(),
-                  children: [
-                    SlidableAction(
-                      onPressed: (context) {
-                        if (state
-                                .recipes[recipeIndex]
-                                .ingredients[ingredientIndex]
-                                .measurements
-                                .length >
-                            1) {
-                          showDialog<String>(
-                              context: context,
-                              builder: (BuildContext context) =>
-                                  DeleteIngredientMeasurementDialog(
-                                      recipe: state.recipes[recipeIndex],
-                                      ingredient: state.recipes[recipeIndex]
-                                          .ingredients[ingredientIndex],
-                                      measurementIndex: index));
-                        } else {
-                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                              content: Text(
-                                  'An ingredient must have at least one measurement')));
-                        }
-                      },
-                      backgroundColor: Colors.red,
-                      foregroundColor: Colors.white,
-                      icon: Icons.delete,
-                      label: 'Delete',
-                    )
-                  ],
-                ),
-                child: AbsorbPointer(
-                  absorbing: state.recipes[recipeIndex].saved,
-                  child: Card(
-                      child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Column(
-                      children: [
-                        DropdownSearch<String>(
-                            dropdownSearchDecoration: const InputDecoration(
-                              icon: Icon(Icons.food_bank_rounded),
-                              labelText: "Measurement method",
-                              helperText: 'How the measurement is measured',
-                            ),
-                            mode: Mode.MENU,
-                            showSelectedItems: true,
-                            showSearchBox: true,
-                            items: Measurement.measurementMethods,
-                            onChanged: (String? answer) => context
-                                .read<RecipeBloc>()
-                                .add(IngredientMeasurementMethodChanged(
-                                    measurementIndex: index,
+      return ListView.builder(
+          shrinkWrap: true,
+          physics: const ClampingScrollPhysics(),
+          padding: const EdgeInsets.all(2.0),
+          itemCount: state.recipes[recipeIndex].ingredients[ingredientIndex]
+              .measurements.length,
+          itemBuilder: (context, index) {
+            return Slidable(
+              key: Key(state.recipes[recipeIndex].ingredients[ingredientIndex]
+                  .measurements[index].id),
+              enabled: !state.recipes[recipeIndex].saved,
+              endActionPane: ActionPane(
+                motion: const ScrollMotion(),
+                children: [
+                  SlidableAction(
+                    onPressed: (context) {
+                      if (state
+                              .recipes[recipeIndex]
+                              .ingredients[ingredientIndex]
+                              .measurements
+                              .length >
+                          1) {
+                        showDialog<String>(
+                            context: context,
+                            builder: (BuildContext context) =>
+                                DeleteIngredientMeasurementDialog(
+                                    recipe: state.recipes[recipeIndex],
                                     ingredient: state.recipes[recipeIndex]
                                         .ingredients[ingredientIndex],
-                                    measurementMethod: answer!,
-                                    recipe: state.recipes[recipeIndex])),
-                            selectedItem: state
-                                .recipes[recipeIndex]
-                                .ingredients[ingredientIndex]
-                                .measurements[index]
-                                .measurementMethod),
-                        DropdownSearch<String>(
-                            dropdownSearchDecoration: const InputDecoration(
-                              icon: Icon(Icons.local_dining_rounded),
-                              labelText: "Measurement unit",
-                              helperText: 'The unit of each measurement value',
-                            ),
-                            mode: Mode.MENU,
-                            showSelectedItems: true,
-                            showSearchBox: true,
-                            items: Measurement.measurementUnits,
-                            onChanged: (String? answer) => context
-                                .read<RecipeBloc>()
-                                .add(IngredientMeasurementUnitChanged(
-                                    measurementIndex: index,
-                                    ingredient: state.recipes[recipeIndex]
-                                        .ingredients[ingredientIndex],
-                                    measurementUnit: answer!,
-                                    recipe: state.recipes[recipeIndex])),
-                            selectedItem: state
-                                .recipes[recipeIndex]
-                                .ingredients[ingredientIndex]
-                                .measurements[index]
-                                .measurementUnit),
-                        TextFormField(
-                          initialValue: state
+                                    measurementIndex: index));
+                      } else {
+                        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                            content: Text(
+                                'An ingredient must have at least one measurement')));
+                      }
+                    },
+                    backgroundColor: Colors.red,
+                    foregroundColor: Colors.white,
+                    icon: Icons.delete,
+                    label: 'Delete',
+                  )
+                ],
+              ),
+              child: AbsorbPointer(
+                absorbing: state.recipes[recipeIndex].saved,
+                child: Card(
+                    child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      DropdownSearch<String>(
+                          dropdownSearchDecoration: const InputDecoration(
+                            icon: Icon(Icons.food_bank_rounded),
+                            labelText: "Measurement method",
+                            helperText: 'How the measurement is measured',
+                          ),
+                          mode: Mode.MENU,
+                          showSelectedItems: true,
+                          showSearchBox: true,
+                          items: Measurement.measurementMethods,
+                          onChanged: (String? answer) => context
+                              .read<RecipeBloc>()
+                              .add(IngredientMeasurementMethodChanged(
+                                  measurementIndex: index,
+                                  ingredient: state.recipes[recipeIndex]
+                                      .ingredients[ingredientIndex],
+                                  measurementMethod: answer!,
+                                  recipe: state.recipes[recipeIndex])),
+                          selectedItem: state
                               .recipes[recipeIndex]
                               .ingredients[ingredientIndex]
                               .measurements[index]
-                              .measurementValue,
-                          decoration: InputDecoration(
-                            icon:
-                                const Icon(Icons.format_list_numbered_rounded),
-                            labelText: 'Measurement value',
-                            helperText: 'Input measurement value',
-                            errorText: !state
-                                    .recipes[recipeIndex]
-                                    .ingredients[ingredientIndex]
-                                    .measurements[index]
-                                    .isValueValid()
-                                ? 'Enter the measured value in 1 to 4 digits'
-                                : null,
+                              .measurementMethod),
+                      DropdownSearch<String>(
+                          dropdownSearchDecoration: const InputDecoration(
+                            icon: Icon(Icons.local_dining_rounded),
+                            labelText: "Measurement unit",
+                            helperText: 'The unit of each measurement value',
                           ),
-                          onChanged: (value) {
-                            context.read<RecipeBloc>().add(
-                                IngredientMeasurementValueChanged(
-                                    measurementIndex: index,
-                                    ingredient: state.recipes[recipeIndex]
-                                        .ingredients[ingredientIndex],
-                                    measurementValue: value,
-                                    recipe: state.recipes[recipeIndex]));
-                          },
-                          textInputAction: TextInputAction.next,
-                          keyboardType: TextInputType.number,
+                          mode: Mode.MENU,
+                          showSelectedItems: true,
+                          showSearchBox: true,
+                          items: Measurement.measurementUnits,
+                          onChanged: (String? answer) => context
+                              .read<RecipeBloc>()
+                              .add(IngredientMeasurementUnitChanged(
+                                  measurementIndex: index,
+                                  ingredient: state.recipes[recipeIndex]
+                                      .ingredients[ingredientIndex],
+                                  measurementUnit: answer!,
+                                  recipe: state.recipes[recipeIndex])),
+                          selectedItem: state
+                              .recipes[recipeIndex]
+                              .ingredients[ingredientIndex]
+                              .measurements[index]
+                              .measurementUnit),
+                      TextFormField(
+                        initialValue: state
+                            .recipes[recipeIndex]
+                            .ingredients[ingredientIndex]
+                            .measurements[index]
+                            .measurementValue,
+                        decoration: InputDecoration(
+                          icon: const Icon(Icons.format_list_numbered_rounded),
+                          labelText: 'Measurement value',
+                          helperText: 'Input measurement value',
+                          errorText: !state
+                                  .recipes[recipeIndex]
+                                  .ingredients[ingredientIndex]
+                                  .measurements[index]
+                                  .isValueValid()
+                              ? 'Enter the measured value in 1 to 4 digits'
+                              : null,
                         ),
-                        const Divider(),
-                        Visibility(
-                          visible: !state.recipes[recipeIndex].saved,
-                          child: ListTile(
-                            title: const Text('Add measurement'),
-                            leading: const Icon(Icons.add),
-                            onTap: () => context.read<RecipeBloc>().add(
-                                IngredientMeasurementAdded(
-                                    ingredient: state.recipes[recipeIndex]
-                                        .ingredients[ingredientIndex],
-                                    recipe: state.recipes[recipeIndex])),
-                          ),
+                        onChanged: (value) {
+                          context.read<RecipeBloc>().add(
+                              IngredientMeasurementValueChanged(
+                                  measurementIndex: index,
+                                  ingredient: state.recipes[recipeIndex]
+                                      .ingredients[ingredientIndex],
+                                  measurementValue: value,
+                                  recipe: state.recipes[recipeIndex]));
+                        },
+                        textInputAction: TextInputAction.next,
+                        keyboardType: TextInputType.number,
+                      ),
+                      const Divider(),
+                      Visibility(
+                        visible: !state.recipes[recipeIndex].saved,
+                        child: ListTile(
+                          title: const Text('Add measurement'),
+                          leading: const Icon(Icons.add),
+                          onTap: () => context.read<RecipeBloc>().add(
+                              IngredientMeasurementAdded(
+                                  ingredient: state.recipes[recipeIndex]
+                                      .ingredients[ingredientIndex],
+                                  recipe: state.recipes[recipeIndex])),
                         ),
-                      ],
-                    ),
-                  )),
-                ),
-              );
-            }),
-      );
+                      ),
+                    ],
+                  ),
+                )),
+              ),
+            );
+          });
     });
   }
 }

--- a/lib/recipe/widgets/probe_form.dart
+++ b/lib/recipe/widgets/probe_form.dart
@@ -22,18 +22,17 @@ class ProbeForm extends StatelessWidget {
                 child: Column(
                   children: [
                     TextFormField(
-                      initialValue: state
-                          .recipes[recipeIndex].probes[probeIndex].probeName,
+                      initialValue:
+                          state.recipes[recipeIndex].probes[probeIndex].name,
                       decoration: InputDecoration(
                           icon: const Icon(Icons.live_help),
                           labelText: 'Probe ${probeIndex + 1}',
                           helperText:
                               'Recipe probe - e.g. Which flour did you use to make roti?',
-                          errorText: (state.recipes[recipeIndex]
-                                          .probes[probeIndex].probeName !=
-                                      null &&
-                                  state.recipes[recipeIndex].probes[probeIndex]
-                                      .probeName!.isEmpty)
+                          errorText: (isFieldModifiedAndEmpty(state
+                                  .recipes[recipeIndex]
+                                  .probes[probeIndex]
+                                  .name))
                               ? 'Probes cannot be empty'
                               : null),
                       onChanged: (value) {

--- a/lib/recipe/widgets/probe_form.dart
+++ b/lib/recipe/widgets/probe_form.dart
@@ -155,7 +155,7 @@ class DeleteProbeOptionDialog extends StatelessWidget {
             'Would you like to delete the ${recipe.probes[probeIndex].probeOptions[probeOptionIndex]['option'] ?? ''} response?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, 'Cancel'),
+            onPressed: () => Navigator.pop(context),
             child: const Text('Cancel'),
           ),
           TextButton(
@@ -164,7 +164,7 @@ class DeleteProbeOptionDialog extends StatelessWidget {
                   recipe: recipe,
                   probeIndex: probeIndex,
                   probeOptionIndex: probeOptionIndex)),
-              Navigator.pop(context, 'Delete'),
+              Navigator.pop(context),
             },
             child: const Text('Delete'),
           ),

--- a/lib/recipe/widgets/probe_form.dart
+++ b/lib/recipe/widgets/probe_form.dart
@@ -17,31 +17,39 @@ class ProbeForm extends StatelessWidget {
           padding: const EdgeInsets.all(8.0),
           child: Column(
             children: [
-              TextFormField(
-                initialValue:
-                    state.recipes[recipeIndex].probes[probeIndex].probeName,
-                decoration: InputDecoration(
-                    icon: const Icon(Icons.live_help),
-                    labelText: 'Probe ${probeIndex + 1}',
-                    helperText:
-                        'Recipe probe - e.g. Which flour did you use to make roti?',
-                    errorText: (state.recipes[recipeIndex].probes[probeIndex]
-                                    .probeName !=
-                                null &&
-                            state.recipes[recipeIndex].probes[probeIndex]
-                                .probeName!.isEmpty)
-                        ? 'Probes cannot be empty'
-                        : null),
-                onChanged: (value) {
-                  context.read<RecipeBloc>().add(ProbeChanged(
-                      recipe: state.recipes[recipeIndex],
-                      probeName: value,
-                      probeIndex: probeIndex));
-                },
-                textCapitalization: TextCapitalization.sentences,
-                textInputAction: TextInputAction.next,
+              AbsorbPointer(
+                absorbing: state.recipes[recipeIndex].saved,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      initialValue: state
+                          .recipes[recipeIndex].probes[probeIndex].probeName,
+                      decoration: InputDecoration(
+                          icon: const Icon(Icons.live_help),
+                          labelText: 'Probe ${probeIndex + 1}',
+                          helperText:
+                              'Recipe probe - e.g. Which flour did you use to make roti?',
+                          errorText: (state.recipes[recipeIndex]
+                                          .probes[probeIndex].probeName !=
+                                      null &&
+                                  state.recipes[recipeIndex].probes[probeIndex]
+                                      .probeName!.isEmpty)
+                              ? 'Probes cannot be empty'
+                              : null),
+                      onChanged: (value) {
+                        context.read<RecipeBloc>().add(ProbeChanged(
+                            recipe: state.recipes[recipeIndex],
+                            probeName: value,
+                            probeIndex: probeIndex));
+                      },
+                      textCapitalization: TextCapitalization.sentences,
+                      textInputAction: TextInputAction.next,
+                    ),
+                    const SizedBox(height: 10),
+                    const ListTile(title: Text('Probe options:')),
+                  ],
+                ),
               ),
-              const ListTile(title: Text('Edit probe options:')),
               Expanded(
                 child: ListView.builder(
                     padding: const EdgeInsets.all(2.0),
@@ -82,38 +90,42 @@ class ProbeForm extends StatelessWidget {
                               )
                             ],
                           ),
-                          child: Card(
-                              child: Padding(
-                            padding: const EdgeInsets.all(8.0),
-                            child: TextFormField(
-                              key: Key(state
-                                  .recipes[recipeIndex]
-                                  .probes[probeIndex]
-                                  .probeOptions[index]['id']!),
-                              initialValue: state
-                                  .recipes[recipeIndex]
-                                  .probes[probeIndex]
-                                  .probeOptions[index]['option'],
-                              decoration: InputDecoration(
-                                icon: const Icon(Icons.edit),
-                                labelText: (index == 0)
-                                    ? 'Default option'
-                                    : 'Option ${index + 1}',
-                                helperText:
-                                    'Probe response option - e.g. Yes/No or a type of ingredient like wheat flour',
+                          child: AbsorbPointer(
+                            absorbing: state.recipes[recipeIndex].saved,
+                            child: Card(
+                                child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: TextFormField(
+                                key: Key(state
+                                    .recipes[recipeIndex]
+                                    .probes[probeIndex]
+                                    .probeOptions[index]['id']!),
+                                initialValue: state
+                                    .recipes[recipeIndex]
+                                    .probes[probeIndex]
+                                    .probeOptions[index]['option'],
+                                decoration: InputDecoration(
+                                  icon: const Icon(Icons.edit),
+                                  labelText: (index == 0)
+                                      ? 'Default option'
+                                      : 'Option ${index + 1}',
+                                  helperText:
+                                      'Probe response option - e.g. Yes/No or a type of ingredient like wheat flour',
+                                ),
+                                onChanged: (value) {
+                                  context.read<RecipeBloc>().add(
+                                      ProbeOptionChanged(
+                                          recipe: state.recipes[recipeIndex],
+                                          probeIndex: probeIndex,
+                                          probeOptionIndex: index,
+                                          probeOptionName: value));
+                                },
+                                textCapitalization:
+                                    TextCapitalization.sentences,
+                                textInputAction: TextInputAction.next,
                               ),
-                              onChanged: (value) {
-                                context.read<RecipeBloc>().add(
-                                    ProbeOptionChanged(
-                                        recipe: state.recipes[recipeIndex],
-                                        probeIndex: probeIndex,
-                                        probeOptionIndex: index,
-                                        probeOptionName: value));
-                              },
-                              textCapitalization: TextCapitalization.sentences,
-                              textInputAction: TextInputAction.next,
-                            ),
-                          )));
+                            )),
+                          ));
                     }),
               )
             ],

--- a/lib/recipe/widgets/probe_form.dart
+++ b/lib/recipe/widgets/probe_form.dart
@@ -110,7 +110,7 @@ class ProbeForm extends StatelessWidget {
                                       ? 'Default option'
                                       : 'Option ${index + 1}',
                                   helperText:
-                                      'Probe response option - e.g. Yes/No or a type of ingredient like wheat flour',
+                                      'Probe response - e.g. Yes/No or an ingredient',
                                 ),
                                 onChanged: (value) {
                                   context.read<RecipeBloc>().add(

--- a/lib/recipe/widgets/probe_form.dart
+++ b/lib/recipe/widgets/probe_form.dart
@@ -57,6 +57,7 @@ class ProbeForm extends StatelessWidget {
                         .probeOptions.length,
                     itemBuilder: (context, index) {
                       return Slidable(
+                          enabled: !state.recipes[recipeIndex].saved,
                           endActionPane: ActionPane(
                             motion: const ScrollMotion(),
                             children: [

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -74,6 +74,9 @@ class RecipeDetails extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
+            Visibility(
+                visible: state.recipes[recipeIndex].saved,
+                child: const SavedRecipeListTile()),
             AbsorbPointer(
                 absorbing: state.recipes[recipeIndex].saved,
                 child: RecipeNameInput(recipeIndex)),
@@ -97,6 +100,20 @@ class RecipeDetails extends StatelessWidget {
         ),
       );
     });
+  }
+}
+
+class SavedRecipeListTile extends StatelessWidget {
+  const SavedRecipeListTile({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const ListTile(
+      title: Text('This recipe is saved'),
+      subtitle: Text(
+          'Saved recipes can no longer be edited. Duplicate this recipe to edit it.'),
+      tileColor: Colors.teal,
+    );
   }
 }
 

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -114,6 +114,7 @@ class RecipeMeasurements extends StatelessWidget {
             itemBuilder: (context, index) {
               return Slidable(
                 key: Key(state.recipes[recipeIndex].measurements[index].id),
+                enabled: !state.recipes[recipeIndex].saved,
                 endActionPane: ActionPane(
                   motion: const ScrollMotion(),
                   children: [

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -19,7 +19,8 @@ class RecipeDetailsScreen extends StatelessWidget {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
       return Scaffold(
         appBar: AppBar(title: const Text('Recipe details')),
-        body: RecipeDetails(recipeIndex),
+        body:
+            RecipeDetails(recipeIndex, assignedFoodItemId: assignedFoodItemId),
         floatingActionButton: Visibility(
           visible:
               !state.recipes[recipeIndex].saved || assignedFoodItemId != null,
@@ -54,7 +55,11 @@ class RecipeDetailsScreen extends StatelessWidget {
 
 class RecipeDetails extends StatelessWidget {
   final int recipeIndex;
-  const RecipeDetails(this.recipeIndex, {Key? key}) : super(key: key);
+  final String? assignedFoodItemId;
+
+  const RecipeDetails(this.recipeIndex,
+      {Key? key, required this.assignedFoodItemId})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -68,7 +73,19 @@ class RecipeDetails extends StatelessWidget {
                 child: RecipeNameInput(recipeIndex)),
             RecipeNumberInput(recipeIndex),
             const SizedBox(height: 10),
-            RecipeMeasurements(recipeIndex),
+            ListTile(
+                onTap: () => {
+                      context.read<RecipeBloc>().add(
+                          RecipeShowMeasurementsChanged(
+                              setShowMeasurements: 'Toggle',
+                              recipe: state.recipes[recipeIndex])),
+                    },
+                title: (state.recipes[recipeIndex].showMeasurements)
+                    ? const Text('Hide measurements')
+                    : const Text('Show measurements')),
+            Visibility(
+                visible: state.recipes[recipeIndex].showMeasurements,
+                child: RecipeMeasurements(recipeIndex)),
           ],
         ),
       );

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -77,8 +77,9 @@ class RecipeDetails extends StatelessWidget {
                 onTap: () => {
                       context.read<RecipeBloc>().add(
                           RecipeShowMeasurementsChanged(
-                              setShowMeasurements: 'Toggle',
-                              recipe: state.recipes[recipeIndex])),
+                              showMeasurements:
+                                  !state.recipes[recipeIndex].showMeasurements,
+                              recipeIndex: recipeIndex)),
                     },
                 title: (state.recipes[recipeIndex].showMeasurements)
                     ? const Text('Hide measurements')

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -9,9 +9,10 @@ import 'package:gibsonify_api/gibsonify_api.dart';
 
 class RecipeDetailsScreen extends StatelessWidget {
   final int recipeIndex;
+  final bool viewedFromCollection;
   final String? assignedFoodItemId;
   const RecipeDetailsScreen(this.recipeIndex,
-      {Key? key, this.assignedFoodItemId})
+      {Key? key, required this.viewedFromCollection, this.assignedFoodItemId})
       : super(key: key);
 
   @override
@@ -19,23 +20,21 @@ class RecipeDetailsScreen extends StatelessWidget {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
       return Scaffold(
         appBar: AppBar(title: const Text('Recipe details')),
-        body:
-            RecipeDetails(recipeIndex, assignedFoodItemId: assignedFoodItemId),
+        body: RecipeDetails(recipeIndex),
         floatingActionButton: Visibility(
-          visible:
-              !state.recipes[recipeIndex].saved || assignedFoodItemId != null,
+          visible: !state.recipes[recipeIndex].saved || viewedFromCollection,
           child: FloatingActionButton.extended(
               heroTag: null,
-              label: assignedFoodItemId == null
+              label: !viewedFromCollection
                   ? const Text("Save Recipe")
                   : const Text("Choose Recipe"),
-              icon: assignedFoodItemId == null
+              icon: !viewedFromCollection
                   ? const Icon(Icons.save_sharp)
                   : const Icon(Icons.check),
               onPressed: () {
                 if (state.recipes[recipeIndex].areMeasurementsFilled() ||
                     state.recipes[recipeIndex].type == 'Standard Recipe') {
-                  if (assignedFoodItemId == null) {
+                  if (!viewedFromCollection) {
                     context.read<RecipeBloc>().add(RecipeStatusChanged(
                         recipe: state.recipes[recipeIndex], recipeSaved: true));
                     context.read<RecipeBloc>().add(const RecipesSaved());
@@ -61,11 +60,8 @@ class RecipeDetailsScreen extends StatelessWidget {
 
 class RecipeDetails extends StatelessWidget {
   final int recipeIndex;
-  final String? assignedFoodItemId;
 
-  const RecipeDetails(this.recipeIndex,
-      {Key? key, required this.assignedFoodItemId})
-      : super(key: key);
+  const RecipeDetails(this.recipeIndex, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -286,14 +286,14 @@ class DeleteRecipeMeasurementDialog extends StatelessWidget {
         content: const Text('Would you like to delete the measurement?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, 'Cancel'),
+            onPressed: () => Navigator.pop(context),
             child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () => {
               context.read<RecipeBloc>().add(RecipeMeasurementDeleted(
                   recipe: recipe, measurementIndex: measurementIndex)),
-              Navigator.pop(context, 'Delete'),
+              Navigator.pop(context),
             },
             child: const Text('Delete'),
           ),

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -33,18 +33,24 @@ class RecipeDetailsScreen extends StatelessWidget {
                   ? const Icon(Icons.save_sharp)
                   : const Icon(Icons.check),
               onPressed: () {
-                if (assignedFoodItemId == null) {
-                  context.read<RecipeBloc>().add(RecipeStatusChanged(
-                      recipe: state.recipes[recipeIndex], recipeSaved: true));
-                  context.read<RecipeBloc>().add(const RecipesSaved());
-                  Navigator.pop(context);
+                if (state.recipes[recipeIndex].areMeasurementsFilled() ||
+                    state.recipes[recipeIndex].type == 'Standard Recipe') {
+                  if (assignedFoodItemId == null) {
+                    context.read<RecipeBloc>().add(RecipeStatusChanged(
+                        recipe: state.recipes[recipeIndex], recipeSaved: true));
+                    context.read<RecipeBloc>().add(const RecipesSaved());
+                    Navigator.pop(context);
+                  } else {
+                    context.read<CollectionBloc>().add(FoodItemRecipeChanged(
+                        foodItemId: assignedFoodItemId!,
+                        foodItemRecipe: state.recipes[recipeIndex]));
+                    context.read<RecipeBloc>().add(const RecipesSaved());
+                    Navigator.pop(context);
+                    Navigator.pop(context);
+                  }
                 } else {
-                  context.read<CollectionBloc>().add(FoodItemRecipeChanged(
-                      foodItemId: assignedFoodItemId!,
-                      foodItemRecipe: state.recipes[recipeIndex]));
-                  context.read<RecipeBloc>().add(const RecipesSaved());
-                  Navigator.pop(context);
-                  Navigator.pop(context);
+                  ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                      content: Text('Each measurement must be filled')));
                 }
               }),
         ),

--- a/lib/recipe/widgets/recipe_details_screen.dart
+++ b/lib/recipe/widgets/recipe_details_screen.dart
@@ -86,15 +86,13 @@ class RecipeDetails extends StatelessWidget {
                 onTap: () => {
                       context.read<RecipeBloc>().add(
                           RecipeShowMeasurementsChanged(
-                              showMeasurements:
-                                  !state.recipes[recipeIndex].showMeasurements,
-                              recipeIndex: recipeIndex)),
+                              showMeasurements: !state.showMeasurements)),
                     },
-                title: (state.recipes[recipeIndex].showMeasurements)
+                title: (state.showMeasurements)
                     ? const Text('Hide measurements')
                     : const Text('Show measurements')),
             Visibility(
-                visible: state.recipes[recipeIndex].showMeasurements,
+                visible: state.showMeasurements,
                 child: RecipeMeasurements(recipeIndex)),
           ],
         ),

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -6,10 +6,7 @@ import 'package:gibsonify/navigation/navigation.dart';
 
 class RecipeIngredientsScreen extends StatelessWidget {
   final int recipeIndex;
-  final String? assignedFoodItemId;
-  const RecipeIngredientsScreen(this.recipeIndex,
-      {Key? key, this.assignedFoodItemId})
-      : super(key: key);
+  const RecipeIngredientsScreen(this.recipeIndex, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -53,11 +53,22 @@ class RecipeForm extends StatelessWidget {
                 absorbing: state.recipes[recipeIndex].saved,
                 child: RecipeNameInput(recipeIndex)),
             const SizedBox(height: 10),
-            ListTile(
-                title: (state.recipes[recipeIndex].ingredients.isNotEmpty)
-                    ? const Text('Ingredients:')
-                    : const Text('Recipe has no ingredients currently')),
-            Ingredients(recipeIndex),
+            Visibility(
+              visible: state.recipes[recipeIndex].ingredients.isNotEmpty,
+              child: ListTile(
+                  onTap: () => {
+                        context.read<RecipeBloc>().add(
+                            RecipeShowIngredientsChanged(
+                                setShowIngredients: 'Toggle',
+                                recipe: state.recipes[recipeIndex])),
+                      },
+                  title: (state.recipes[recipeIndex].showIngredients)
+                      ? const Text('Hide ingredients')
+                      : const Text('Show ingredients')),
+            ),
+            Visibility(
+                visible: state.recipes[recipeIndex].showIngredients,
+                child: Ingredients(recipeIndex)),
           ],
         ),
       );

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -52,7 +52,7 @@ class RecipeForm extends StatelessWidget {
             ListTile(
                 title: (state.recipes[recipeIndex].ingredients.isNotEmpty)
                     ? const Text('Ingredients:')
-                    : null),
+                    : const Text('Recipe has no ingredients currently')),
             Ingredients(recipeIndex),
           ],
         ),

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -110,17 +110,9 @@ class Ingredients extends StatelessWidget {
               itemBuilder: (context, index) {
                 return Card(
                     child: ListTile(
-                        title: (state.recipes[recipeIndex].ingredients[index]
-                                    .name ==
-                                "Other (please specify)")
-                            // TODO: Implement a better implementation for this check
-                            // possibly a flag to show customName is chosen
-                            ? Text(state.recipes[recipeIndex].ingredients[index]
-                                    .customName ??
-                                '')
-                            : Text(state.recipes[recipeIndex].ingredients[index]
-                                    .name ??
-                                ''),
+                        title: Text(state
+                            .recipes[recipeIndex].ingredients[index]
+                            .ingredientNameDisplay()),
                         subtitle: Text(state.recipes[recipeIndex]
                                 .ingredients[index].description ??
                             ''),

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -18,20 +18,23 @@ class RecipeIngredientsScreen extends StatelessWidget {
       return Scaffold(
           appBar: AppBar(title: const Text('Recipe ingredients')),
           body: RecipeForm(recipeIndex),
-          floatingActionButton: FloatingActionButton.extended(
-              heroTag: null,
-              label: const Text("New Ingredient"),
-              icon: const Icon(Icons.add),
-              onPressed: () => {
-                    context.read<RecipeBloc>().add(
-                        IngredientAdded(recipe: state.recipes[recipeIndex])),
-                    Navigator.pushNamed(context, PageRouter.ingredient,
-                        arguments: {
-                          'recipeIndex': recipeIndex,
-                          'ingredientIndex':
-                              state.recipes[recipeIndex].ingredients.length,
-                        }),
-                  }));
+          floatingActionButton: Visibility(
+            visible: !state.recipes[recipeIndex].saved,
+            child: FloatingActionButton.extended(
+                heroTag: null,
+                label: const Text("New Ingredient"),
+                icon: const Icon(Icons.add),
+                onPressed: () => {
+                      context.read<RecipeBloc>().add(
+                          IngredientAdded(recipe: state.recipes[recipeIndex])),
+                      Navigator.pushNamed(context, PageRouter.ingredient,
+                          arguments: {
+                            'recipeIndex': recipeIndex,
+                            'ingredientIndex':
+                                state.recipes[recipeIndex].ingredients.length,
+                          }),
+                    }),
+          ));
     });
   }
 }
@@ -47,7 +50,9 @@ class RecipeForm extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
-            RecipeNameInput(recipeIndex),
+            AbsorbPointer(
+                absorbing: state.recipes[recipeIndex].saved,
+                child: RecipeNameInput(recipeIndex)),
             const SizedBox(height: 10),
             ListTile(
                 title: (state.recipes[recipeIndex].ingredients.isNotEmpty)

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -75,11 +75,10 @@ class RecipeNameInput extends StatelessWidget {
             icon: const Icon(Icons.assignment_rounded),
             labelText: 'Recipe Name',
             helperText: 'A valid recipe name, e.g. Aloo bandhgobhi',
-            // TODO: Refactor the error condition into a reusable method
-            errorText: (state.recipes[recipeIndex].name != null &&
-                    state.recipes[recipeIndex].name == '')
-                ? 'Enter a valid recipe name, e.g. Aloo bandhgobhi'
-                : null,
+            errorText:
+                (isFieldModifiedAndEmpty(state.recipes[recipeIndex].name))
+                    ? 'Enter a valid recipe name, e.g. Aloo bandhgobhi'
+                    : null,
           ),
           onChanged: (value) {
             context.read<RecipeBloc>().add(RecipeNameChanged(

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -49,6 +49,9 @@ class RecipeForm extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: <Widget>[
+            Visibility(
+                visible: state.recipes[recipeIndex].saved,
+                child: const SavedRecipeListTile()),
             AbsorbPointer(
                 absorbing: state.recipes[recipeIndex].saved,
                 child: RecipeNameInput(recipeIndex)),

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -166,16 +166,15 @@ class IngredientOptions extends StatelessWidget {
       final List<Widget> options = [
         const ListTile(title: Text('Ingredient options')),
         const Divider(),
-        // ListTile(
-        //   leading: const Icon(Icons.copy),
-        //   title: const Text('Duplicate'),
-        //   onTap: () => {
-        //     context.read<RecipeBloc>().add(RecipeDuplicated(
-        //         recipe: recipe, employeeNumber: employeeNumber)),
-        //     context.read<RecipeBloc>().add(const RecipesSaved()),
-        //     Navigator.pop(context, 'Duplicate')
-        //   },
-        // ),
+        ListTile(
+          leading: const Icon(Icons.copy),
+          title: const Text('Duplicate'),
+          onTap: () => {
+            context.read<RecipeBloc>().add(
+                IngredientDuplicated(recipe: recipe, ingredient: ingredient)),
+            Navigator.pop(context, 'Duplicate')
+          },
+        ),
         ListTile(
           leading: const Icon(Icons.delete),
           title: const Text('Delete'),

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -145,7 +145,7 @@ class Ingredients extends StatelessWidget {
                     trailing:
                         state.recipes[recipeIndex].ingredients[index].saved
                             ? const Icon(Icons.done)
-                            : const Icon(Icons.rotate_left_rounded),
+                            : const Icon(Icons.new_releases),
                     onTap: () => {
                       Navigator.pushNamed(context, PageRouter.ingredient,
                           arguments: {

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -59,8 +59,9 @@ class RecipeForm extends StatelessWidget {
                   onTap: () => {
                         context.read<RecipeBloc>().add(
                             RecipeShowIngredientsChanged(
-                                setShowIngredients: 'Toggle',
-                                recipe: state.recipes[recipeIndex])),
+                                showIngredients:
+                                    !state.recipes[recipeIndex].showIngredients,
+                                recipeIndex: recipeIndex)),
                       },
                   title: (state.recipes[recipeIndex].showIngredients)
                       ? const Text('Hide ingredients')

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -177,7 +177,7 @@ class IngredientOptions extends StatelessWidget {
           onTap: () => {
             context.read<RecipeBloc>().add(
                 IngredientDuplicated(recipe: recipe, ingredient: ingredient)),
-            Navigator.pop(context, 'Duplicate')
+            Navigator.pop(context)
           },
         ),
         ListTile(
@@ -187,7 +187,7 @@ class IngredientOptions extends StatelessWidget {
             context
                 .read<RecipeBloc>()
                 .add(IngredientDeleted(recipe: recipe, ingredient: ingredient)),
-            Navigator.pop(context, 'Delete')
+            Navigator.pop(context)
           },
         )
       ];

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -62,16 +62,14 @@ class RecipeForm extends StatelessWidget {
                   onTap: () => {
                         context.read<RecipeBloc>().add(
                             RecipeShowIngredientsChanged(
-                                showIngredients:
-                                    !state.recipes[recipeIndex].showIngredients,
-                                recipeIndex: recipeIndex)),
+                                showIngredients: !state.showIngredients)),
                       },
-                  title: (state.recipes[recipeIndex].showIngredients)
+                  title: (state.showIngredients)
                       ? const Text('Hide ingredients')
                       : const Text('Show ingredients')),
             ),
             Visibility(
-                visible: state.recipes[recipeIndex].showIngredients,
+                visible: state.showIngredients,
                 child: Ingredients(recipeIndex)),
           ],
         ),

--- a/lib/recipe/widgets/recipe_ingredients_screen.dart
+++ b/lib/recipe/widgets/recipe_ingredients_screen.dart
@@ -152,41 +152,6 @@ class Ingredients extends StatelessWidget {
   }
 }
 
-class DeleteIngredientDialog extends StatelessWidget {
-  final Recipe recipe;
-  final Ingredient ingredient;
-
-  const DeleteIngredientDialog(
-      {Key? key, required this.recipe, required this.ingredient})
-      : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    String? ingredientName = ingredient.name;
-    return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
-      return AlertDialog(
-        title: const Text('Delete ingredient'),
-        content:
-            Text('Would you like to delete the $ingredientName ingredient?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, 'Cancel'),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => {
-              context.read<RecipeBloc>().add(
-                  IngredientDeleted(recipe: recipe, ingredient: ingredient)),
-              Navigator.pop(context, 'Delete')
-            },
-            child: const Text('Delete'),
-          ),
-        ],
-      );
-    });
-  }
-}
-
 class IngredientOptions extends StatelessWidget {
   final Recipe recipe;
   final Ingredient ingredient;

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -277,7 +277,7 @@ class ProbeOptions extends StatelessWidget {
             context
                 .read<RecipeBloc>()
                 .add(ProbeDuplicated(recipe: recipe, probe: probe)),
-            Navigator.pop(context, 'Duplicate')
+            Navigator.pop(context)
           },
         ),
         ListTile(
@@ -287,7 +287,7 @@ class ProbeOptions extends StatelessWidget {
             context
                 .read<RecipeBloc>()
                 .add(ProbeDeleted(recipe: recipe, probe: probe)),
-            Navigator.pop(context, 'Delete')
+            Navigator.pop(context)
           },
         )
       ];

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -61,115 +61,135 @@ class ProbeList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<RecipeBloc, RecipeState>(builder: (context, state) {
-      return Column(
-        children: [
-          ProbesPrompt(
-              recipeIndex: recipeIndex, assignedFoodItemId: assignedFoodItemId),
-          Visibility(
-            visible: (state.recipes[recipeIndex].type == 'Standard Recipe' &&
-                assignedFoodItemId != null &&
-                isFieldNotNullAndNotEmpty(foodItemDescription)),
-            child: ListTile(
-              title: const Text('Comments:'),
-              subtitle: Text(foodItemDescription ?? ''),
-              leading: const Icon(Icons.description),
-            ),
-          ),
-          Visibility(
-            visible: (state.recipes[recipeIndex].type == 'Standard Recipe'),
-            child: Expanded(
-              child: ListView.builder(
-                  padding: const EdgeInsets.all(2.0),
-                  itemCount: state.recipes[recipeIndex].probes.length,
-                  itemBuilder: (context, index) {
-                    return Slidable(
-                      endActionPane: ActionPane(
-                        motion: const ScrollMotion(),
-                        children: [
-                          SlidableAction(
-                            onPressed: (context) {
-                              showDialog<String>(
-                                  context: context,
-                                  builder: (BuildContext context) =>
-                                      DeleteProbeDialog(
-                                          recipe: state.recipes[recipeIndex],
-                                          probe: state.recipes[recipeIndex]
-                                              .probes[index]));
-                            },
-                            backgroundColor: Colors.red,
-                            foregroundColor: Colors.white,
-                            icon: Icons.delete,
-                            label: 'Delete',
-                          )
-                        ],
-                      ),
-                      child: Card(
-                          child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Column(
-                          children: [
-                            ListTile(
-                              title: Text(state.recipes[recipeIndex]
-                                      .probes[index].probeName ??
-                                  ''),
-                              leading: const Icon(Icons.live_help),
-                              trailing: Visibility(
-                                visible: (assignedFoodItemId != null),
-                                child: Checkbox(
-                                  value: state.recipes[recipeIndex]
-                                      .probes[index].checked,
-                                  onChanged: (bool? value) {
-                                    context.read<RecipeBloc>().add(ProbeChecked(
-                                        recipe: state.recipes[recipeIndex],
-                                        probeCheck: value!,
-                                        probeIndex: index));
-                                  },
-                                ),
+      return Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            ProbesPrompt(
+                recipeIndex: recipeIndex,
+                assignedFoodItemId: assignedFoodItemId),
+            Visibility(
+                visible: (state.recipes[recipeIndex].type == 'Standard Recipe'),
+                child: Expanded(
+                  child: Column(children: [
+                    RecipeNameInput(recipeIndex),
+                    Visibility(
+                        visible: (assignedFoodItemId != null &&
+                            isFieldNotNullAndNotEmpty(foodItemDescription)),
+                        child: TextFormField(
+                          initialValue: foodItemDescription,
+                          decoration: const InputDecoration(
+                            icon: Icon(Icons.info),
+                            labelText: 'Food item comments',
+                          ),
+                          enabled: false,
+                        )),
+                    const SizedBox(height: 10),
+                    ListTile(
+                        title: (state.recipes[recipeIndex].probes.isNotEmpty)
+                            ? const Text('Probes:')
+                            : const Text('Recipe has no probes currently')),
+                    Expanded(
+                      child: ListView.builder(
+                          padding: const EdgeInsets.all(2.0),
+                          itemCount: state.recipes[recipeIndex].probes.length,
+                          itemBuilder: (context, index) {
+                            return Slidable(
+                              endActionPane: ActionPane(
+                                motion: const ScrollMotion(),
+                                children: [
+                                  SlidableAction(
+                                    onPressed: (context) {
+                                      showDialog<String>(
+                                          context: context,
+                                          builder: (BuildContext context) =>
+                                              DeleteProbeDialog(
+                                                  recipe: state
+                                                      .recipes[recipeIndex],
+                                                  probe: state
+                                                      .recipes[recipeIndex]
+                                                      .probes[index]));
+                                    },
+                                    backgroundColor: Colors.red,
+                                    foregroundColor: Colors.white,
+                                    icon: Icons.delete,
+                                    label: 'Delete',
+                                  )
+                                ],
                               ),
-                              onTap: () => {
-                                if (assignedFoodItemId == null)
-                                  {
-                                    Navigator.pushNamed(
-                                        context, PageRouter.editProbe,
-                                        arguments: {
-                                          'recipeIndex': recipeIndex,
-                                          'probeIndex': index,
-                                        })
-                                  }
-                              },
-                            ),
-                            Visibility(
-                              visible: (assignedFoodItemId != null),
-                              child: DropdownSearch<String>(
-                                  mode: Mode.MENU,
-                                  showSelectedItems: true,
-                                  showSearchBox: true,
-                                  items: state.recipes[recipeIndex].probes[index]
-                                      .optionsList(),
-                                  onChanged: (String? answer) => context
-                                      .read<RecipeBloc>()
-                                      .add(ProbeOptionSelected(
-                                          recipe: state.recipes[recipeIndex],
-                                          probeIndex: index,
-                                          answer: answer!)),
-                                  selectedItem: (state.recipes[recipeIndex]
-                                                  .probes[index].answer ==
-                                              null ||
-                                          state.recipes[recipeIndex]
-                                                  .probes[index].answer ==
-                                              '')
-                                      ? state.recipes[recipeIndex].probes[index]
-                                          .optionsList()[0]
-                                      : state.recipes[recipeIndex].probes[index].answer),
-                            )
-                          ],
-                        ),
-                      )),
-                    );
-                  }),
-            ),
-          ),
-        ],
+                              child: Card(
+                                  child: Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Column(
+                                  children: [
+                                    ListTile(
+                                      title: Text(state.recipes[recipeIndex]
+                                              .probes[index].probeName ??
+                                          ''),
+                                      leading: const Icon(Icons.live_help),
+                                      trailing: Visibility(
+                                        visible: (assignedFoodItemId != null),
+                                        child: Checkbox(
+                                          value: state.recipes[recipeIndex]
+                                              .probes[index].checked,
+                                          onChanged: (bool? value) {
+                                            context.read<RecipeBloc>().add(
+                                                ProbeChecked(
+                                                    recipe: state
+                                                        .recipes[recipeIndex],
+                                                    probeCheck: value!,
+                                                    probeIndex: index));
+                                          },
+                                        ),
+                                      ),
+                                      onTap: () => {
+                                        if (assignedFoodItemId == null)
+                                          {
+                                            Navigator.pushNamed(
+                                                context, PageRouter.editProbe,
+                                                arguments: {
+                                                  'recipeIndex': recipeIndex,
+                                                  'probeIndex': index,
+                                                })
+                                          }
+                                      },
+                                    ),
+                                    Visibility(
+                                      visible: (assignedFoodItemId != null),
+                                      child: DropdownSearch<String>(
+                                          mode: Mode.MENU,
+                                          showSelectedItems: true,
+                                          showSearchBox: true,
+                                          items: state.recipes[recipeIndex]
+                                              .probes[index]
+                                              .optionsList(),
+                                          onChanged: (String? answer) => context
+                                              .read<RecipeBloc>()
+                                              .add(ProbeOptionSelected(
+                                                  recipe: state
+                                                      .recipes[recipeIndex],
+                                                  probeIndex: index,
+                                                  answer: answer!)),
+                                          selectedItem: (state.recipes[recipeIndex].probes[index].answer == null ||
+                                                  state
+                                                          .recipes[recipeIndex]
+                                                          .probes[index]
+                                                          .answer ==
+                                                      '')
+                                              ? state.recipes[recipeIndex].probes[index]
+                                                  .optionsList()[0]
+                                              : state.recipes[recipeIndex].probes[index].answer),
+                                    )
+                                  ],
+                                ),
+                              )),
+                            );
+                          }),
+                    ),
+                  ]),
+                )),
+          ],
+        ),
       );
     });
   }

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -102,9 +102,9 @@ class ProbeList extends StatelessWidget {
                               child: Column(
                                 children: [
                                   ListTile(
-                                      title: Text(state.recipes[recipeIndex]
-                                              .probes[index].probeName ??
-                                          ''),
+                                      title: Text(state
+                                          .recipes[recipeIndex].probes[index]
+                                          .probeNameDisplay()),
                                       leading: const Icon(Icons.live_help),
                                       trailing: Visibility(
                                         visible: (assignedFoodItemId != null),

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -8,10 +8,14 @@ import 'package:dropdown_search/dropdown_search.dart';
 
 class RecipeProbesScreen extends StatelessWidget {
   final int recipeIndex;
+  final bool viewedFromCollection;
   final String? assignedFoodItemId;
   final String? foodItemDescription;
   const RecipeProbesScreen(this.recipeIndex,
-      {Key? key, this.assignedFoodItemId, this.foodItemDescription})
+      {Key? key,
+      required this.viewedFromCollection,
+      this.assignedFoodItemId,
+      this.foodItemDescription})
       : super(key: key);
 
   @override
@@ -21,7 +25,7 @@ class RecipeProbesScreen extends StatelessWidget {
           appBar: AppBar(title: const Text('Recipe probes list')),
           floatingActionButton: Visibility(
             visible: (state.recipes[recipeIndex].type == 'Standard Recipe' &&
-                assignedFoodItemId == null &&
+                !viewedFromCollection &&
                 !state.recipes[recipeIndex].saved),
             child: FloatingActionButton.extended(
                 label: const Text("Add probe"),
@@ -40,6 +44,7 @@ class RecipeProbesScreen extends StatelessWidget {
           ),
           body: ProbeList(
             recipeIndex: recipeIndex,
+            viewedFromCollection: viewedFromCollection,
             assignedFoodItemId: assignedFoodItemId,
             foodItemDescription: foodItemDescription,
           ));
@@ -49,12 +54,14 @@ class RecipeProbesScreen extends StatelessWidget {
 
 class ProbeList extends StatelessWidget {
   final int recipeIndex;
+  final bool viewedFromCollection;
   final String? assignedFoodItemId;
   final String? foodItemDescription;
 
   const ProbeList(
       {Key? key,
       required this.recipeIndex,
+      required this.viewedFromCollection,
       this.assignedFoodItemId,
       this.foodItemDescription})
       : super(key: key);
@@ -71,6 +78,7 @@ class ProbeList extends StatelessWidget {
                 child: const SavedRecipeListTile()),
             ProbesPrompt(
               recipeIndex: recipeIndex,
+              viewedFromCollection: viewedFromCollection,
               assignedFoodItemId: assignedFoodItemId,
               foodItemDescription: foodItemDescription,
             ),
@@ -82,7 +90,7 @@ class ProbeList extends StatelessWidget {
                         absorbing: state.recipes[recipeIndex].saved,
                         child: RecipeNameInput(recipeIndex)),
                     Visibility(
-                        visible: (assignedFoodItemId != null &&
+                        visible: (viewedFromCollection &&
                             isFieldNotNullAndNotEmpty(foodItemDescription)),
                         child: TextFormField(
                           initialValue: foodItemDescription,
@@ -113,7 +121,7 @@ class ProbeList extends StatelessWidget {
                                           .probeNameDisplay()),
                                       leading: const Icon(Icons.live_help),
                                       trailing: Visibility(
-                                        visible: (assignedFoodItemId != null),
+                                        visible: viewedFromCollection,
                                         child: Checkbox(
                                           value: state.recipes[recipeIndex]
                                               .probes[index].checked,
@@ -128,7 +136,7 @@ class ProbeList extends StatelessWidget {
                                         ),
                                       ),
                                       onTap: () => {
-                                            if (assignedFoodItemId == null)
+                                            if (!viewedFromCollection)
                                               {
                                                 Navigator.pushNamed(context,
                                                     PageRouter.editProbe,
@@ -141,7 +149,7 @@ class ProbeList extends StatelessWidget {
                                           },
                                       onLongPress: (state
                                                   .recipes[recipeIndex].saved ||
-                                              assignedFoodItemId != null)
+                                              viewedFromCollection)
                                           ? null
                                           : () => showModalBottomSheet(
                                               context: context,
@@ -154,7 +162,7 @@ class ProbeList extends StatelessWidget {
                                                         .probes[index]);
                                               })),
                                   Visibility(
-                                    visible: (assignedFoodItemId != null),
+                                    visible: (viewedFromCollection),
                                     child: DropdownSearch<String>(
                                         mode: Mode.MENU,
                                         showSelectedItems: true,
@@ -195,11 +203,13 @@ class ProbeList extends StatelessWidget {
 
 class ProbesPrompt extends StatelessWidget {
   final int recipeIndex;
+  final bool viewedFromCollection;
   final String? assignedFoodItemId;
   final String? foodItemDescription;
   const ProbesPrompt(
       {Key? key,
       required this.recipeIndex,
+      required this.viewedFromCollection,
       this.assignedFoodItemId,
       this.foodItemDescription})
       : super(key: key);
@@ -215,7 +225,7 @@ class ProbesPrompt extends StatelessWidget {
             subtitle: Text('Use a standard recipe to add probes'),
             tileColor: Colors.blue,
           );
-        } else if (assignedFoodItemId != null &&
+        } else if (viewedFromCollection &&
             recipeState.recipes[recipeIndex].allProbesChecked &&
             recipeState.recipes[recipeIndex].allProbeAnswersStandard &&
             recipeState.recipes[recipeIndex].type == 'Standard Recipe' &&
@@ -225,7 +235,7 @@ class ProbesPrompt extends StatelessWidget {
             subtitle: Text('Confirm recipe volume on Recipe Details page'),
             tileColor: Colors.green,
           );
-        } else if (assignedFoodItemId != null &&
+        } else if (viewedFromCollection &&
             recipeState.recipes[recipeIndex].allProbesChecked &&
             !recipeState.recipes[recipeIndex].allProbeAnswersStandard &&
             recipeState.recipes[recipeIndex].type == 'Standard Recipe' &&
@@ -242,6 +252,7 @@ class ProbesPrompt extends StatelessWidget {
               Navigator.pop(context),
               Navigator.pushNamed(context, PageRouter.recipe, arguments: {
                 'recipeIndex': recipeIndex + 1,
+                'viewedFromCollection': viewedFromCollection,
                 'assignedFoodItemId': assignedFoodItemId,
                 'foodItemDescription': foodItemDescription,
                 'selectedScreen': SelectedRecipeScreen.ingredientScreen

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -65,6 +65,9 @@ class ProbeList extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Column(
           children: [
+            Visibility(
+                visible: state.recipes[recipeIndex].saved,
+                child: const SavedRecipeListTile()),
             ProbesPrompt(
                 recipeIndex: recipeIndex,
                 assignedFoodItemId: assignedFoodItemId),

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -235,7 +235,7 @@ class ProbesPrompt extends StatelessWidget {
             subtitle: const Text('Tap here to create a modified recipe'),
             tileColor: Colors.red,
             onTap: () => {
-              context.read<RecipeBloc>().add(RecipeModified(
+              context.read<RecipeBloc>().add(ModifiedRecipeCreated(
                   recipe: recipeState.recipes[recipeIndex],
                   employeeNumber: loginState.loginInfo.employeeId!)),
               context.read<RecipeBloc>().add(const RecipesSaved()),

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -67,9 +67,10 @@ class ProbeList extends StatelessWidget {
               recipeIndex: recipeIndex, assignedFoodItemId: assignedFoodItemId),
           Visibility(
             visible: (state.recipes[recipeIndex].type == 'Standard Recipe' &&
-                assignedFoodItemId != null),
+                assignedFoodItemId != null &&
+                isFieldNotNullAndNotEmpty(foodItemDescription)),
             child: ListTile(
-              title: const Text('Food ingredients'),
+              title: const Text('Comments:'),
               subtitle: Text(foodItemDescription ?? ''),
               leading: const Icon(Icons.description),
             ),

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -21,7 +21,8 @@ class RecipeProbesScreen extends StatelessWidget {
           appBar: AppBar(title: const Text('Recipe probes list')),
           floatingActionButton: Visibility(
             visible: (state.recipes[recipeIndex].type == 'Standard Recipe' &&
-                assignedFoodItemId == null),
+                assignedFoodItemId == null &&
+                !state.recipes[recipeIndex].saved),
             child: FloatingActionButton.extended(
                 label: const Text("Add probe"),
                 icon: const Icon(Icons.add),
@@ -72,7 +73,9 @@ class ProbeList extends StatelessWidget {
                 visible: (state.recipes[recipeIndex].type == 'Standard Recipe'),
                 child: Expanded(
                   child: Column(children: [
-                    RecipeNameInput(recipeIndex),
+                    AbsorbPointer(
+                        absorbing: state.recipes[recipeIndex].saved,
+                        child: RecipeNameInput(recipeIndex)),
                     Visibility(
                         visible: (assignedFoodItemId != null &&
                             isFieldNotNullAndNotEmpty(foodItemDescription)),

--- a/lib/recipe/widgets/recipe_probes_screen.dart
+++ b/lib/recipe/widgets/recipe_probes_screen.dart
@@ -133,8 +133,9 @@ class ProbeList extends StatelessWidget {
                                                     })
                                               }
                                           },
-                                      onLongPress: state
-                                              .recipes[recipeIndex].saved
+                                      onLongPress: (state
+                                                  .recipes[recipeIndex].saved ||
+                                              assignedFoodItemId != null)
                                           ? null
                                           : () => showModalBottomSheet(
                                               context: context,

--- a/packages/gibsonify_api/lib/src/models/measurement.dart
+++ b/packages/gibsonify_api/lib/src/models/measurement.dart
@@ -113,4 +113,13 @@ class Measurement extends Equatable {
     // TODO: add checks for different options
     return !isFieldModifiedAndEmpty(measurementUnit);
   }
+
+  bool isMeasurementFilled() {
+    // TODO: Valid methods should only check for error criteria, not null
+    // checks. Once this is changed, include valid checks as AND addition to
+    // result of this function.
+    return (isFieldNotNullAndNotEmpty(measurementMethod) &&
+        isFieldNotNullAndNotEmpty(measurementUnit) &&
+        isFieldNotNullAndNotEmpty(measurementValue));
+  }
 }

--- a/packages/gibsonify_api/lib/src/models/measurement.dart
+++ b/packages/gibsonify_api/lib/src/models/measurement.dart
@@ -115,11 +115,11 @@ class Measurement extends Equatable {
   }
 
   bool isMeasurementFilled() {
-    // TODO: Valid methods should only check for error criteria, not null
-    // checks. Once this is changed, include valid checks as AND addition to
-    // result of this function.
     return (isFieldNotNullAndNotEmpty(measurementMethod) &&
+        isMethodValid() &&
         isFieldNotNullAndNotEmpty(measurementUnit) &&
-        isFieldNotNullAndNotEmpty(measurementValue));
+        isUnitValid() &&
+        isFieldNotNullAndNotEmpty(measurementValue) &&
+        isValueValid());
   }
 }

--- a/packages/gibsonify_api/lib/src/models/recipe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe.dart
@@ -57,6 +57,16 @@ class Recipe extends Equatable {
     return '';
   }
 
+  bool areMeasurementsFilled() {
+    bool result = true;
+    for (Measurement measurement in measurements) {
+      if (!measurement.isMeasurementFilled()) {
+        result = false;
+      }
+    }
+    return result;
+  }
+
   Recipe copyWith({
     String? name,
     String? employeeNumber,

--- a/packages/gibsonify_api/lib/src/models/recipe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe.dart
@@ -18,6 +18,8 @@ class Recipe extends Equatable {
     this.allProbeAnswersStandard = true,
     this.allProbesChecked = false,
     this.saved = false,
+    this.showMeasurements = false,
+    this.showIngredients = false,
   })  : number = number ?? const Uuid().v4(),
         date = date ?? DateFormat('yyyy-MM-dd').format(DateTime.now()),
         measurements = measurements ?? [Measurement()];
@@ -33,6 +35,8 @@ class Recipe extends Equatable {
   final bool allProbesChecked;
   final bool allProbeAnswersStandard;
   final bool saved;
+  final bool showMeasurements;
+  final bool showIngredients;
 
   String recipeNameDisplay() {
     if (isFieldNotNullAndNotEmpty(name)) {
@@ -65,6 +69,8 @@ class Recipe extends Equatable {
     bool? allProbesChecked,
     bool? allProbeAnswersStandard,
     bool? saved,
+    bool? showMeasurements,
+    bool? showIngredients,
   }) {
     return Recipe(
       name: name ?? this.name,
@@ -79,6 +85,8 @@ class Recipe extends Equatable {
       allProbeAnswersStandard:
           allProbeAnswersStandard ?? this.allProbeAnswersStandard,
       saved: saved ?? this.saved,
+      showMeasurements: showMeasurements ?? this.showMeasurements,
+      showIngredients: showIngredients ?? this.showIngredients,
     );
   }
 
@@ -95,6 +103,8 @@ class Recipe extends Equatable {
         allProbesChecked,
         allProbeAnswersStandard,
         saved,
+        showMeasurements,
+        showIngredients
       ];
 
   Recipe.fromJson(Map<String, dynamic> json)
@@ -109,7 +119,9 @@ class Recipe extends Equatable {
         allProbesChecked = json['allProbesChecked'] == 'true' ? true : false,
         allProbeAnswersStandard =
             json['allProbeAnswersStandard'] == 'true' ? true : false,
-        saved = json['saved'] == 'true' ? true : false;
+        saved = json['saved'] == 'true' ? true : false,
+        showMeasurements = json['showMeasurements'] == 'true' ? true : false,
+        showIngredients = json['showIngredients'] == 'true' ? true : false;
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
@@ -124,6 +136,8 @@ class Recipe extends Equatable {
     data['allProbesChecked'] = allProbesChecked.toString();
     data['allProbeAnswersStandard'] = allProbeAnswersStandard.toString();
     data['saved'] = saved.toString();
+    data['showMeasurements'] = showMeasurements.toString();
+    data['showIngredients'] = showIngredients.toString();
     return data;
   }
 

--- a/packages/gibsonify_api/lib/src/models/recipe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe.dart
@@ -18,8 +18,8 @@ class Recipe extends Equatable {
     this.allProbeAnswersStandard = true,
     this.allProbesChecked = false,
     this.saved = false,
-    this.showMeasurements = false,
-    this.showIngredients = false,
+    this.showMeasurements = true,
+    this.showIngredients = true,
   })  : number = number ?? const Uuid().v4(),
         date = date ?? DateFormat('yyyy-MM-dd').format(DateTime.now()),
         measurements = measurements ?? [Measurement()];

--- a/packages/gibsonify_api/lib/src/models/recipe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe.dart
@@ -34,7 +34,14 @@ class Recipe extends Equatable {
   final bool allProbeAnswersStandard;
   final bool saved;
 
-  String ingredientNamesString() {
+  String recipeNameDisplay() {
+    if (isFieldNotNullAndNotEmpty(name)) {
+      return name!;
+    }
+    return 'Unnamed recipe';
+  }
+
+  String ingredientNamesDisplay() {
     final List<String?> ingredientNames = [];
     for (Ingredient ingredient in ingredients) {
       ingredientNames.add(ingredient.name);

--- a/packages/gibsonify_api/lib/src/models/recipe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe.dart
@@ -34,6 +34,18 @@ class Recipe extends Equatable {
   final bool allProbeAnswersStandard;
   final bool saved;
 
+  String ingredientNamesString() {
+    final List<String?> ingredientNames = [];
+    for (Ingredient ingredient in ingredients) {
+      ingredientNames.add(ingredient.name);
+    }
+    String joinedNames = ingredientNames.join(', ');
+    if (joinedNames.isNotEmpty) {
+      return '\n\nIngredients: ' + joinedNames;
+    }
+    return '';
+  }
+
   Recipe copyWith({
     String? name,
     String? employeeNumber,

--- a/packages/gibsonify_api/lib/src/models/recipe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe.dart
@@ -18,8 +18,6 @@ class Recipe extends Equatable {
     this.allProbeAnswersStandard = true,
     this.allProbesChecked = false,
     this.saved = false,
-    this.showMeasurements = true,
-    this.showIngredients = true,
   })  : number = number ?? const Uuid().v4(),
         date = date ?? DateFormat('yyyy-MM-dd').format(DateTime.now()),
         measurements = measurements ?? [Measurement()];
@@ -35,8 +33,6 @@ class Recipe extends Equatable {
   final bool allProbesChecked;
   final bool allProbeAnswersStandard;
   final bool saved;
-  final bool showMeasurements;
-  final bool showIngredients;
 
   String recipeNameDisplay() {
     if (isFieldNotNullAndNotEmpty(name)) {
@@ -79,8 +75,6 @@ class Recipe extends Equatable {
     bool? allProbesChecked,
     bool? allProbeAnswersStandard,
     bool? saved,
-    bool? showMeasurements,
-    bool? showIngredients,
   }) {
     return Recipe(
       name: name ?? this.name,
@@ -95,8 +89,6 @@ class Recipe extends Equatable {
       allProbeAnswersStandard:
           allProbeAnswersStandard ?? this.allProbeAnswersStandard,
       saved: saved ?? this.saved,
-      showMeasurements: showMeasurements ?? this.showMeasurements,
-      showIngredients: showIngredients ?? this.showIngredients,
     );
   }
 
@@ -113,8 +105,6 @@ class Recipe extends Equatable {
         allProbesChecked,
         allProbeAnswersStandard,
         saved,
-        showMeasurements,
-        showIngredients
       ];
 
   Recipe.fromJson(Map<String, dynamic> json)
@@ -129,9 +119,7 @@ class Recipe extends Equatable {
         allProbesChecked = json['allProbesChecked'] == 'true' ? true : false,
         allProbeAnswersStandard =
             json['allProbeAnswersStandard'] == 'true' ? true : false,
-        saved = json['saved'] == 'true' ? true : false,
-        showMeasurements = json['showMeasurements'] == 'true' ? true : false,
-        showIngredients = json['showIngredients'] == 'true' ? true : false;
+        saved = json['saved'] == 'true' ? true : false;
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
@@ -146,8 +134,6 @@ class Recipe extends Equatable {
     data['allProbesChecked'] = allProbesChecked.toString();
     data['allProbeAnswersStandard'] = allProbeAnswersStandard.toString();
     data['saved'] = saved.toString();
-    data['showMeasurements'] = showMeasurements.toString();
-    data['showIngredients'] = showIngredients.toString();
     return data;
   }
 

--- a/packages/gibsonify_api/lib/src/models/recipe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe.dart
@@ -44,7 +44,7 @@ class Recipe extends Equatable {
   String ingredientNamesDisplay() {
     final List<String?> ingredientNames = [];
     for (Ingredient ingredient in ingredients) {
-      ingredientNames.add(ingredient.name);
+      ingredientNames.add(ingredient.ingredientNameDisplay());
     }
     String joinedNames = ingredientNames.join(', ');
     if (joinedNames.isNotEmpty) {

--- a/packages/gibsonify_api/lib/src/models/recipe_ingredient.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe_ingredient.dart
@@ -37,6 +37,16 @@ class Ingredient extends Equatable {
     return 'Unnamed ingredient';
   }
 
+  bool areMeasurementsFilled() {
+    bool result = true;
+    for (Measurement measurement in measurements) {
+      if (!measurement.isMeasurementFilled()) {
+        result = false;
+      }
+    }
+    return result;
+  }
+
   Ingredient copyWith(
       {String? name,
       String? customName,

--- a/packages/gibsonify_api/lib/src/models/recipe_ingredient.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe_ingredient.dart
@@ -11,6 +11,7 @@ class Ingredient extends Equatable {
       this.customName,
       this.description,
       this.cookingState,
+      this.customCookingState,
       List<Measurement>? measurements,
       this.foodComposition,
       this.saved = false,
@@ -22,6 +23,7 @@ class Ingredient extends Equatable {
   final String? customName;
   final String? description;
   final String? cookingState;
+  final String? customCookingState;
   final List<Measurement> measurements;
   final Map<String, dynamic>? foodComposition;
   final bool saved;
@@ -35,6 +37,16 @@ class Ingredient extends Equatable {
       return name!;
     }
     return 'Unnamed ingredient';
+  }
+
+  String cookingStateDisplay() {
+    if (isFieldNotNullAndNotEmpty(cookingState)) {
+      if (cookingState == 'Other (please specify)') {
+        return customCookingState ?? 'Unspecified cooking state';
+      }
+      return cookingState!;
+    }
+    return 'Unnamed cooking state';
   }
 
   bool areMeasurementsFilled() {
@@ -52,6 +64,7 @@ class Ingredient extends Equatable {
       String? customName,
       String? description,
       String? cookingState,
+      String? customCookingState,
       List<Measurement>? measurements,
       Map<String, dynamic>? foodComposition,
       bool? saved,
@@ -61,6 +74,7 @@ class Ingredient extends Equatable {
         customName: customName ?? this.customName,
         description: description ?? this.description,
         cookingState: cookingState ?? this.cookingState,
+        customCookingState: customCookingState ?? this.customCookingState,
         measurements: measurements ?? this.measurements,
         foodComposition: foodComposition ?? this.foodComposition,
         saved: saved ?? this.saved,
@@ -73,6 +87,7 @@ class Ingredient extends Equatable {
         customName,
         description,
         cookingState,
+        customCookingState,
         measurements,
         foodComposition,
         saved,
@@ -89,6 +104,7 @@ class Ingredient extends Equatable {
         customName = json['customName'],
         description = json['description'],
         cookingState = json['cookingState'],
+        customCookingState = json['customCookingState'],
         measurements = Measurement.jsonDecodeMeasurements(json['measurements']),
         foodComposition = jsonDecode(json['foodComposition']),
         saved = json['saved'] == 'true' ? true : false,
@@ -101,6 +117,7 @@ class Ingredient extends Equatable {
     data['customName'] = customName;
     data['description'] = description;
     data['cookingState'] = cookingState;
+    data['customCookingState'] = customCookingState;
     data['measurements'] = jsonEncode(measurements);
     data['foodComposition'] = jsonEncode(foodComposition);
     data['saved'] = saved.toString();
@@ -113,6 +130,6 @@ class Ingredient extends Equatable {
 
     // TODO: how should customName be handled?
     return '"${ingredientNameDisplay()}","$description",'
-        '"$cookingState","$measurementsCombined"';
+        '"${cookingStateDisplay()}","$measurementsCombined"';
   }
 }

--- a/packages/gibsonify_api/lib/src/models/recipe_ingredient.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe_ingredient.dart
@@ -27,6 +27,16 @@ class Ingredient extends Equatable {
   final bool saved;
   final String id;
 
+  String ingredientNameDisplay() {
+    if (isFieldNotNullAndNotEmpty(name)) {
+      if (name == 'Other (please specify)') {
+        return customName ?? 'Unspecified Ingredient';
+      }
+      return name!;
+    }
+    return 'Unnamed ingredient';
+  }
+
   Ingredient copyWith(
       {String? name,
       String? customName,
@@ -92,7 +102,7 @@ class Ingredient extends Equatable {
     String measurementsCombined = combineMeasurements(measurements);
 
     // TODO: how should customName be handled?
-    return '"${name ?? customName}","$description",'
+    return '"${ingredientNameDisplay()}","$description",'
         '"$cookingState","$measurementsCombined"';
   }
 }

--- a/packages/gibsonify_api/lib/src/models/recipe_probe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe_probe.dart
@@ -26,7 +26,7 @@ class Probe extends Equatable {
     if (isFieldNotNullAndNotEmpty(name)) {
       return name!;
     }
-    return 'Unnamed Probe';
+    return 'Unnamed probe';
   }
 
   List<String> optionsList() {

--- a/packages/gibsonify_api/lib/src/models/recipe_probe.dart
+++ b/packages/gibsonify_api/lib/src/models/recipe_probe.dart
@@ -2,9 +2,11 @@ import 'package:equatable/equatable.dart';
 import 'dart:convert';
 import 'package:uuid/uuid.dart';
 
+import 'package:gibsonify_api/gibsonify_api.dart';
+
 class Probe extends Equatable {
   Probe(
-      {this.probeName, // TODO: rename to `name`
+      {this.name,
       this.checked = false,
       this.answer,
       // TODO: why does this need to be a dictionary with uuids?
@@ -15,10 +17,17 @@ class Probe extends Equatable {
               {'option': 'No', 'id': const Uuid().v4()}
             ];
 
-  final String? probeName;
+  final String? name;
   final bool checked;
   final String? answer;
   final List<Map<String, dynamic>> probeOptions;
+
+  String probeNameDisplay() {
+    if (isFieldNotNullAndNotEmpty(name)) {
+      return name!;
+    }
+    return 'Unnamed Probe';
+  }
 
   List<String> optionsList() {
     final List<String> options = [];
@@ -36,7 +45,7 @@ class Probe extends Equatable {
   }
 
   Probe.fromJson(Map<String, dynamic> json)
-      : probeName = json['probeName'],
+      : name = json['name'],
         checked = json['checked'] == 'true' ? true : false,
         answer = json['answer'],
         probeOptions =
@@ -44,7 +53,7 @@ class Probe extends Equatable {
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
-    data['probeName'] = probeName;
+    data['name'] = name;
     data['checked'] = checked.toString();
     data['answer'] = answer;
     data['probeOptions'] = jsonEncode(probeOptions);
@@ -60,22 +69,22 @@ class Probe extends Equatable {
     probeAnswers =
         probeAnswers.substring(0, probeAnswers.length - ' + '.length);
 
-    return '"$probeName","$probeAnswers"';
+    return '"$name","$probeAnswers"';
   }
 
   Probe copyWith(
-      {String? probeName,
+      {String? name,
       bool? checked,
       String? answer,
       List<Map<String, dynamic>>? probeOptions,
       String? id}) {
     return Probe(
-        probeName: probeName ?? this.probeName,
+        name: name ?? this.name,
         checked: checked ?? this.checked,
         answer: answer ?? this.answer,
         probeOptions: probeOptions ?? this.probeOptions);
   }
 
   @override
-  List<Object?> get props => [probeName, checked, answer, probeOptions];
+  List<Object?> get props => [name, checked, answer, probeOptions];
 }


### PR DESCRIPTION
Following feedback from ICRISAT, recipe modification has been over hauled. Individual recipes can now be duplicated, deleted or modified (if the recipe is a Standard recipe), via long press which reveals a drawer (BottomModalSheet) of options. Duplicating a recipe retains its initial type, while modifying a standard recipe creates an identical recipe with type changed to 'Modified Recipe'.
Complementary to this, saved recipes can no longer be edited, the intended way to edit a saved recipe is via duplicating/modifying it.
Other feedback implemented includes:
- hiding measurements and ingredients of a Standard Recipe when accessed via collection
- restricting saving of non-standard/modified recipe when measurement fields have not been filled.
- custom cooking state specification
- other visual improvements including showing ingredient information on the Recipes Screen