### PR TITLE
ci: workflows for release bump, build and release

### DIFF
--- a/.github/workflows/bump_release_version.yml
+++ b/.github/workflows/bump_release_version.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Bump version and update changelog
         uses: commitizen-tools/commitizen-action@master
         with:

--- a/.github/workflows/bump_release_version.yml
+++ b/.github/workflows/bump_release_version.yml
@@ -1,0 +1,17 @@
+name: bump_release_version
+on: workflow_dispatch
+
+jobs:
+  bump-version-commitizen:
+    #if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    name: "Bump version and create changelog with commitizen"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Bump version and update changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/bump_release_version.yml
+++ b/.github/workflows/bump_release_version.yml
@@ -1,5 +1,7 @@
 name: bump_release_version
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    branches: main
 
 jobs:
   bump-version-commitizen:

--- a/.github/workflows/create_and_build_release.yml
+++ b/.github/workflows/create_and_build_release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           echo "$UPLOAD_KEYSTORE" | base64 --decode > android/upload-keystore.jks
           echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=upload\nstoreFile=android/upload-keystore.jks>" > android/key.properties
-        with:
+        env:
           upload_keystore: ${{ secrets.ANDROID_UPLOAD_KEYSTORE }}
           upload_keystore_password: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
       - name: Build APK

--- a/.github/workflows/create_and_build_release.yml
+++ b/.github/workflows/create_and_build_release.yml
@@ -20,11 +20,12 @@ jobs:
         run: |
           echo "$UPLOAD_KEYSTORE" | base64 --decode > android/upload-keystore.jks
           echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=upload\nstoreFile=android/upload-keystore.jks" > android/key.properties
-      - name: Build APK
+      - name: Setup Flutter environment
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.0.0'
           channel: 'stable'
+      - name: Build release APK
         run: |
           flutter pub get
           flutter test

--- a/.github/workflows/create_and_build_release.yml
+++ b/.github/workflows/create_and_build_release.yml
@@ -1,6 +1,6 @@
 name: create_and_build_release
 on:
-  push:
+  create:
     tags:
       - "*" # Will trigger for every tag, alternative: 'v*'
 
@@ -13,30 +13,41 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Prepare signing key
-        env:
-          UPLOAD_KEYSTORE: ${{ secrets.ANDROID_UPLOAD_KEYSTORE }}
-          UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
-        run: |
-          echo "$UPLOAD_KEYSTORE" | base64 --decode > android/upload-keystore.jks
-          echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=upload\nstoreFile=android/upload-keystore.jks" > android/key.properties
       - name: Setup Flutter environment
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.0.0'
           channel: 'stable'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Install Commitizen
+        run: |
+          python -m pip install Commitizen
+      - name: Prepare signing key
+        env:
+          UPLOAD_KEYSTORE: ${{ secrets.ANDROID_UPLOAD_KEYSTORE }}
+          UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
+        run: |
+          echo "$UPLOAD_KEYSTORE" | base64 --decode > android/app/upload-keystore.jks
+          echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=gibsonify_key\nstoreFile=upload-keystore.jks" > android/key.properties
       - name: Build release APK
         run: |
-          flutter pub get
-          flutter test
-          flutter build apk --release
-      - name: Generate APK checksum
+          flutter build apk --release --build-number $(git tag | wc -l)
+      - name: Build release app bundle
         run: |
-          sha256sum -a 256 build\app\outputs\apk\release\app-release.apk > app-release-checksum.txt
+          flutter build appbundle --release --build-number $(git tag | wc -l)
+      - name: Generate checksums
+        run: |
+          sha256sum build/app/outputs/apk/release/app-release.apk build/app/outputs/bundle/release/app-release.aab > checksums.txt
+      - name: Generate incremental changelog
+        run: |
+          cz changelog --dry-run --start-rev $(git tag --sort=creatordate | sed -n 'x;$p') > INCREMENTAL.md
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
+          body_path: INCREMENTAL.md
           files: |
-            build\app\outputs\apk\release\app-release.apk
-            app-release-checksum.txt
+            build/app/outputs/apk/release/app-release.apk
+            build/app/outputs/bundle/release/app-release.aab
+            checksums.txt
         

--- a/.github/workflows/create_and_build_release.yml
+++ b/.github/workflows/create_and_build_release.yml
@@ -1,0 +1,40 @@
+name: create_and_build_release
+on:
+  push:
+    tags:
+      - "*" # Will trigger for every tag, alternative: 'v*'
+
+jobs:
+  build-release-apk:
+    runs-on: ubuntu-latest
+    name: "Build signed APK and release"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Prepare signing key
+        run: |
+          echo "$UPLOAD_KEYSTORE" | base64 --decode > android/upload-keystore.jks
+          echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=upload\nstoreFile=android/upload-keystore.jks>" > android/key.properties
+        with:
+          upload_keystore: ${{ secrets.ANDROID_UPLOAD_KEYSTORE }}
+          upload_keystore_password: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
+      - name: Build APK
+        - uses: subosito/flutter-action@v2
+          with:
+            flutter-version: '3.0.0'
+            channel: 'stable'
+        - run: flutter pub get
+        - run: flutter test
+        - run: flutter build apk --release
+      - name: Generate APK checksum
+        run: |
+          sha256sum -a 256 build\app\outputs\apk\release\app-release.apk > app-release-checksum.txt
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            build\app\outputs\apk\release\app-release.apk
+            app-release-checksum.txt
+        

--- a/.github/workflows/create_and_build_release.yml
+++ b/.github/workflows/create_and_build_release.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Prepare signing key
+        env:
+          UPLOAD_KEYSTORE: ${{ secrets.ANDROID_UPLOAD_KEYSTORE }}
+          UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
         run: |
           echo "$UPLOAD_KEYSTORE" | base64 --decode > android/upload-keystore.jks
           echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=upload\nstoreFile=android/upload-keystore.jks>" > android/key.properties
-        env:
-          upload_keystore: ${{ secrets.ANDROID_UPLOAD_KEYSTORE }}
-          upload_keystore_password: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
       - name: Build APK
         - uses: subosito/flutter-action@v2
           with:

--- a/.github/workflows/create_and_build_release.yml
+++ b/.github/workflows/create_and_build_release.yml
@@ -19,15 +19,16 @@ jobs:
           UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
         run: |
           echo "$UPLOAD_KEYSTORE" | base64 --decode > android/upload-keystore.jks
-          echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=upload\nstoreFile=android/upload-keystore.jks>" > android/key.properties
+          echo -e "storePassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyPassword=${UPLOAD_KEYSTORE_PASSWORD}\nkeyAlias=upload\nstoreFile=android/upload-keystore.jks" > android/key.properties
       - name: Build APK
-        - uses: subosito/flutter-action@v2
-          with:
-            flutter-version: '3.0.0'
-            channel: 'stable'
-        - run: flutter pub get
-        - run: flutter test
-        - run: flutter build apk --release
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.0.0'
+          channel: 'stable'
+        run: |
+          flutter pub get
+          flutter test
+          flutter build apk --release
       - name: Generate APK checksum
         run: |
           sha256sum -a 256 build\app\outputs\apk\release\app-release.apk > app-release-checksum.txt


### PR DESCRIPTION
- Adds a manually triggered workflow that automates release version bump, changelog update and tag through Commitizen
- Adds a workflow that builds a signed APK and AAB when a new tag is created and creates a new release
- Addresses #54 - build number incremented in above workflow