### PR TITLE
feat(respondent): anthropometric data collection

### DIFF
--- a/lib/household/bloc/household_bloc.dart
+++ b/lib/household/bloc/household_bloc.dart
@@ -21,6 +21,7 @@ class HouseholdBloc extends Bloc<HouseholdEvent, HouseholdState> {
     on<SaveCollectionRequested>(_onSaveCollectionRequested);
     on<CollectionOpened>(_onCollectionOpened);
     on<DeleteCollectionRequested>(_onDeleteCollectionRequested);
+    on<NewAnthropometricsSaveRequested>(_onNewAnthropometricsSaveRequested);
   }
 
   void _onHouseholdOpened(
@@ -118,6 +119,23 @@ class HouseholdBloc extends Bloc<HouseholdEvent, HouseholdState> {
     final collections = respondent.collections.toList();
     collections.removeAt(event.index);
     final updatedRespondent = respondent.copyWith(collections: collections);
+    var respondents = state.household!.respondents.toList();
+    respondents[state.selectedRespondentIndex!] = updatedRespondent;
+    final household = state.household!.copyWith(respondents: respondents);
+    await _isarRepository.saveNewHousehold(household);
+    emit(HouseholdLoaded(
+        household: household,
+        selectedRespondentIndex: state.selectedRespondentIndex!));
+  }
+
+  void _onNewAnthropometricsSaveRequested(NewAnthropometricsSaveRequested event,
+      Emitter<HouseholdState> emit) async {
+    final respondent =
+        state.household!.respondents[state.selectedRespondentIndex!];
+    final updatedRespondent = respondent.copyWith(anthropometrics: [
+      ...respondent.anthropometrics,
+      event.anthropometrics
+    ]);
     var respondents = state.household!.respondents.toList();
     respondents[state.selectedRespondentIndex!] = updatedRespondent;
     final household = state.household!.copyWith(respondents: respondents);

--- a/lib/household/bloc/household_bloc.dart
+++ b/lib/household/bloc/household_bloc.dart
@@ -22,6 +22,7 @@ class HouseholdBloc extends Bloc<HouseholdEvent, HouseholdState> {
     on<CollectionOpened>(_onCollectionOpened);
     on<DeleteCollectionRequested>(_onDeleteCollectionRequested);
     on<NewAnthropometricsSaveRequested>(_onNewAnthropometricsSaveRequested);
+    on<DeleteAnthropometricsRequested>(_onDeleteAnthropometricsRequested);
   }
 
   void _onHouseholdOpened(
@@ -136,6 +137,23 @@ class HouseholdBloc extends Bloc<HouseholdEvent, HouseholdState> {
       ...respondent.anthropometrics,
       event.anthropometrics
     ]);
+    var respondents = state.household!.respondents.toList();
+    respondents[state.selectedRespondentIndex!] = updatedRespondent;
+    final household = state.household!.copyWith(respondents: respondents);
+    await _isarRepository.saveNewHousehold(household);
+    emit(HouseholdLoaded(
+        household: household,
+        selectedRespondentIndex: state.selectedRespondentIndex!));
+  }
+
+  void _onDeleteAnthropometricsRequested(DeleteAnthropometricsRequested event,
+      Emitter<HouseholdState> emit) async {
+    final respondent =
+        state.household!.respondents[state.selectedRespondentIndex!];
+    final anthropometrics = respondent.anthropometrics.toList();
+    anthropometrics.removeAt(event.index);
+    final updatedRespondent =
+        respondent.copyWith(anthropometrics: anthropometrics);
     var respondents = state.household!.respondents.toList();
     respondents[state.selectedRespondentIndex!] = updatedRespondent;
     final household = state.household!.copyWith(respondents: respondents);

--- a/lib/household/bloc/household_event.dart
+++ b/lib/household/bloc/household_event.dart
@@ -97,3 +97,12 @@ class NewAnthropometricsSaveRequested extends HouseholdEvent {
   @override
   List<Object> get props => [anthropometrics];
 }
+
+class DeleteAnthropometricsRequested extends HouseholdEvent {
+  final int index;
+
+  const DeleteAnthropometricsRequested({required this.index});
+
+  @override
+  List<Object> get props => [index];
+}

--- a/lib/household/bloc/household_event.dart
+++ b/lib/household/bloc/household_event.dart
@@ -88,3 +88,12 @@ class DeleteCollectionRequested extends HouseholdEvent {
   @override
   List<Object> get props => [index];
 }
+
+class NewAnthropometricsSaveRequested extends HouseholdEvent {
+  final Anthropometrics anthropometrics;
+
+  const NewAnthropometricsSaveRequested({required this.anthropometrics});
+
+  @override
+  List<Object> get props => [anthropometrics];
+}

--- a/lib/household/view/create_anthropometrics.dart
+++ b/lib/household/view/create_anthropometrics.dart
@@ -14,6 +14,12 @@ class CreateAnthropometricsPage extends StatelessWidget {
     final formKey = GlobalKey<FormBuilderState>();
     bool changed = false;
 
+    final formValidators = FormBuilderValidators.compose([
+      FormBuilderValidators.numeric(),
+      FormBuilderValidators.min(0,
+          inclusive: false, errorText: 'Value must be greater than 0.')
+    ]);
+
     return BlocBuilder<HouseholdBloc, HouseholdState>(
       builder: (context, state) {
         return WillPopScope(
@@ -103,7 +109,7 @@ class CreateAnthropometricsPage extends StatelessWidget {
                       icon: Icon(Icons.scale),
                     ),
                     onChanged: (value) => changed = true,
-                    validator: FormBuilderValidators.numeric(),
+                    validator: formValidators,
                   ),
                   FormBuilderTextField(
                     name: 'height',
@@ -114,7 +120,7 @@ class CreateAnthropometricsPage extends StatelessWidget {
                       icon: Icon(Icons.height),
                     ),
                     onChanged: (value) => changed = true,
-                    validator: FormBuilderValidators.numeric(),
+                    validator: formValidators,
                   ),
                   FormBuilderTextField(
                     name: 'waist',
@@ -125,7 +131,7 @@ class CreateAnthropometricsPage extends StatelessWidget {
                       icon: Icon(Icons.storm),
                     ),
                     onChanged: (value) => changed = true,
-                    validator: FormBuilderValidators.numeric(),
+                    validator: formValidators,
                   ),
                   FormBuilderTextField(
                     name: 'armLength',
@@ -136,7 +142,7 @@ class CreateAnthropometricsPage extends StatelessWidget {
                       icon: Icon(Icons.emoji_people),
                     ),
                     onChanged: (value) => changed = true,
-                    validator: FormBuilderValidators.numeric(),
+                    validator: formValidators,
                   ),
                   FormBuilderTextField(
                     name: 'handSpan',
@@ -147,7 +153,7 @@ class CreateAnthropometricsPage extends StatelessWidget {
                       icon: Icon(Icons.front_hand),
                     ),
                     onChanged: (value) => changed = true,
-                    validator: FormBuilderValidators.numeric(),
+                    validator: formValidators,
                   ),
                 ]),
               ),

--- a/lib/household/view/create_anthropometrics.dart
+++ b/lib/household/view/create_anthropometrics.dart
@@ -3,8 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
-
-import '../bloc/household_bloc.dart';
+import 'package:gibsonify/household/household.dart';
 
 class CreateAnthropometricsPage extends StatelessWidget {
   const CreateAnthropometricsPage({Key? key}) : super(key: key);

--- a/lib/household/view/create_anthropometrics.dart
+++ b/lib/household/view/create_anthropometrics.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:gibsonify_api/gibsonify_api.dart';
+
+import '../bloc/household_bloc.dart';
+
+class CreateAnthropometricsPage extends StatelessWidget {
+  const CreateAnthropometricsPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, [bool mounted = true]) {
+    final formKey = GlobalKey<FormBuilderState>();
+    bool changed = false;
+
+    return BlocBuilder<HouseholdBloc, HouseholdState>(
+      builder: (context, state) {
+        return WillPopScope(
+          onWillPop: () async {
+            if (!changed) {
+              return true;
+            }
+            bool willLeave = false;
+            await showDialog(
+                context: context,
+                barrierDismissible: false,
+                builder: (_) => AlertDialog(
+                      title: const Text('Are you sure?'),
+                      content: const Text('Any unsaved changes will be lost.'),
+                      actions: [
+                        ElevatedButton(
+                            onPressed: () {
+                              willLeave = true;
+                              Navigator.of(context).pop();
+                            },
+                            child: const Text('Yes')),
+                        TextButton(
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('No'))
+                      ],
+                    ));
+            return willLeave;
+          },
+          child: Scaffold(
+            appBar: AppBar(
+              title: const Text('Add anthropometric record'),
+              actions: [
+                IconButton(
+                    onPressed: () {
+                      if (formKey.currentState!.saveAndValidate()) {
+                        final date = formKey.currentState!.value['date'];
+                        final weight = double.tryParse(
+                            formKey.currentState!.value['weight'].toString());
+                        final height = double.tryParse(
+                            formKey.currentState!.value['height'].toString());
+                        final waist = double.tryParse(
+                            formKey.currentState!.value['waist'].toString());
+                        final armLength = double.tryParse(formKey
+                            .currentState!.value['armLength']
+                            .toString());
+                        final handSpan = double.tryParse(
+                            formKey.currentState!.value['handSpan'].toString());
+
+                        context.read<HouseholdBloc>().add(
+                            NewAnthropometricsSaveRequested(
+                                anthropometrics: Anthropometrics(
+                                    date: date,
+                                    weight: weight,
+                                    height: height,
+                                    waist: waist,
+                                    armLength: armLength,
+                                    handSpan: handSpan)));
+                        Navigator.pop(context);
+                      }
+                    },
+                    icon: const Icon(Icons.save))
+              ],
+            ),
+            body: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: FormBuilder(
+                key: formKey,
+                child: Column(children: [
+                  FormBuilderDateTimePicker(
+                    name: 'date',
+                    decoration: const InputDecoration(
+                      label: Text('Date'),
+                      icon: Icon(Icons.calendar_today),
+                    ),
+                    onChanged: (value) => changed = true,
+                    inputType: InputType.date,
+                    lastDate: DateTime.now(),
+                    initialValue: DateTime.now(),
+                    validator: FormBuilderValidators.required(),
+                  ),
+                  FormBuilderTextField(
+                    name: 'weight',
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: const InputDecoration(
+                      label: Text('Weight (kg)'),
+                      icon: Icon(Icons.scale),
+                    ),
+                    onChanged: (value) => changed = true,
+                    validator: FormBuilderValidators.numeric(),
+                  ),
+                  FormBuilderTextField(
+                    name: 'height',
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: const InputDecoration(
+                      label: Text('Height (cm)'),
+                      icon: Icon(Icons.height),
+                    ),
+                    onChanged: (value) => changed = true,
+                    validator: FormBuilderValidators.numeric(),
+                  ),
+                  FormBuilderTextField(
+                    name: 'waist',
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: const InputDecoration(
+                      label: Text('Waist (cm)'),
+                      icon: Icon(Icons.storm),
+                    ),
+                    onChanged: (value) => changed = true,
+                    validator: FormBuilderValidators.numeric(),
+                  ),
+                  FormBuilderTextField(
+                    name: 'armLength',
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: const InputDecoration(
+                      label: Text('Arm Length (cm)'),
+                      icon: Icon(Icons.emoji_people),
+                    ),
+                    onChanged: (value) => changed = true,
+                    validator: FormBuilderValidators.numeric(),
+                  ),
+                  FormBuilderTextField(
+                    name: 'handSpan',
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: const InputDecoration(
+                      label: Text('Hand Span (cm)'),
+                      icon: Icon(Icons.front_hand),
+                    ),
+                    onChanged: (value) => changed = true,
+                    validator: FormBuilderValidators.numeric(),
+                  ),
+                ]),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/household/view/view.dart
+++ b/lib/household/view/view.dart
@@ -4,3 +4,4 @@ export 'create_respondent.dart';
 export 'view_respondent.dart';
 export 'edit_respondent.dart';
 export 'create_anthropometrics.dart';
+export 'view_anthropometrics.dart';

--- a/lib/household/view/view.dart
+++ b/lib/household/view/view.dart
@@ -3,3 +3,4 @@ export 'edit_household.dart';
 export 'create_respondent.dart';
 export 'view_respondent.dart';
 export 'edit_respondent.dart';
+export 'create_anthropometrics.dart';

--- a/lib/household/view/view_anthropometrics.dart
+++ b/lib/household/view/view_anthropometrics.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+
+import '../bloc/household_bloc.dart';
+
+class ViewAnthropometricsPage extends StatelessWidget {
+  final int index;
+
+  const ViewAnthropometricsPage({Key? key, required this.index})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context, [bool mounted = true]) {
+    return BlocBuilder<HouseholdBloc, HouseholdState>(
+      builder: (context, state) {
+        final record = state.household!
+            .respondents[state.selectedRespondentIndex!].anthropometrics[index];
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(record.date.toString()),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: FormBuilder(
+              child: Column(children: [
+                FormBuilderDateTimePicker(
+                  name: 'date',
+                  enabled: false,
+                  decoration: const InputDecoration(
+                    label: Text('Date'),
+                    icon: Icon(Icons.calendar_today),
+                  ),
+                  inputType: InputType.date,
+                  initialValue: record.date,
+                ),
+                FormBuilderTextField(
+                  name: 'weight',
+                  enabled: false,
+                  decoration: const InputDecoration(
+                    label: Text('Weight (kg)'),
+                    icon: Icon(Icons.scale),
+                  ),
+                  initialValue: record.weight?.toString() ?? '',
+                ),
+                FormBuilderTextField(
+                  name: 'height',
+                  enabled: false,
+                  decoration: const InputDecoration(
+                    label: Text('Height (cm)'),
+                    icon: Icon(Icons.height),
+                  ),
+                  initialValue: record.height?.toString() ?? '',
+                ),
+                FormBuilderTextField(
+                  name: 'waist',
+                  enabled: false,
+                  decoration: const InputDecoration(
+                    label: Text('Waist (cm)'),
+                    icon: Icon(Icons.storm),
+                  ),
+                  initialValue: record.waist?.toString() ?? '',
+                ),
+                FormBuilderTextField(
+                  name: 'armLength',
+                  enabled: false,
+                  decoration: const InputDecoration(
+                    label: Text('Arm Length (cm)'),
+                    icon: Icon(Icons.emoji_people),
+                  ),
+                  initialValue: record.armLength?.toString() ?? '',
+                ),
+                FormBuilderTextField(
+                  name: 'handSpan',
+                  enabled: false,
+                  decoration: const InputDecoration(
+                    label: Text('Hand Span (cm)'),
+                    icon: Icon(Icons.front_hand),
+                  ),
+                  initialValue: record.handSpan?.toString() ?? '',
+                ),
+              ]),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/household/view/view_anthropometrics.dart
+++ b/lib/household/view/view_anthropometrics.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:intl/intl.dart';
 
 import '../bloc/household_bloc.dart';
 
@@ -12,6 +13,8 @@ class ViewAnthropometricsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context, [bool mounted = true]) {
+    final formatter = DateFormat('yyyy-MM-dd');
+
     return BlocBuilder<HouseholdBloc, HouseholdState>(
       builder: (context, state) {
         final record = state.household!
@@ -19,7 +22,7 @@ class ViewAnthropometricsPage extends StatelessWidget {
 
         return Scaffold(
           appBar: AppBar(
-            title: Text(record.date.toString()),
+            title: Text(formatter.format(record.date!)),
           ),
           body: Padding(
             padding: const EdgeInsets.all(8.0),

--- a/lib/household/view/view_anthropometrics.dart
+++ b/lib/household/view/view_anthropometrics.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:intl/intl.dart';
-
-import '../bloc/household_bloc.dart';
+import 'package:gibsonify/household/household.dart';
 
 class ViewAnthropometricsPage extends StatelessWidget {
   final int index;

--- a/lib/household/view/view_respondent.dart
+++ b/lib/household/view/view_respondent.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gibsonify/household/household.dart';
 import 'package:gibsonify/navigation/models/page_router.dart';
+import 'package:intl/intl.dart';
 
 class ViewRespondentPage extends StatelessWidget {
   final int index;
@@ -10,6 +11,8 @@ class ViewRespondentPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final formatter = DateFormat('yyyy-MM-dd');
+
     return BlocBuilder<HouseholdBloc, HouseholdState>(
       builder: (context, state) {
         final respondent = state.household!.respondents[index];
@@ -59,11 +62,13 @@ class ViewRespondentPage extends StatelessWidget {
                       itemBuilder: (context, index) {
                         final anthropometrics =
                             respondent.anthropometrics[index];
+                        final date = anthropometrics.date != null
+                            ? formatter.format(anthropometrics.date!)
+                            : 'No date';
+
                         return Card(
                           child: ListTile(
-                            title: Text(anthropometrics.date != null
-                                ? anthropometrics.date.toString()
-                                : 'No date'),
+                            title: Text(date),
                             onTap: () => {
                               Navigator.pushNamed(
                                   context, PageRouter.viewAnthropometrics,
@@ -73,10 +78,7 @@ class ViewRespondentPage extends StatelessWidget {
                                 context: context,
                                 builder: (context) {
                                   return AnthropometricsOptions(
-                                      index: index,
-                                      date: anthropometrics.date != null
-                                          ? anthropometrics.date.toString()
-                                          : 'No date');
+                                      index: index, date: date);
                                 }),
                           ),
                         );

--- a/lib/household/view/view_respondent.dart
+++ b/lib/household/view/view_respondent.dart
@@ -153,6 +153,37 @@ class ViewRespondentPage extends StatelessWidget {
   }
 }
 
+class AnthropometricsOptions extends StatelessWidget {
+  final int index;
+  final String date;
+
+  const AnthropometricsOptions(
+      {Key? key, required this.index, required this.date})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<HouseholdBloc, HouseholdState>(
+        builder: (context, state) {
+      final List<Widget> options = [
+        ListTile(title: Text(date)),
+        const Divider(),
+        ListTile(
+          leading: const Icon(Icons.delete),
+          title: const Text('Delete'),
+          onTap: () {
+            context
+                .read<HouseholdBloc>()
+                .add(DeleteAnthropometricsRequested(index: index));
+            Navigator.pop(context);
+          },
+        )
+      ];
+      return Wrap(children: options);
+    });
+  }
+}
+
 class CollectionOptions extends StatelessWidget {
   final int index;
   final String date;

--- a/lib/household/view/view_respondent.dart
+++ b/lib/household/view/view_respondent.dart
@@ -39,6 +39,42 @@ class ViewRespondentPage extends StatelessWidget {
                 children: [
                   const Padding(
                     padding: EdgeInsets.all(8.0),
+                    child: Icon(Icons.straighten),
+                  ),
+                  Text('Anthropometrics',
+                      style: Theme.of(context).textTheme.headline6),
+                  const Spacer(),
+                  IconButton(
+                      onPressed: () => {
+                            Navigator.pushNamed(
+                                context, PageRouter.createAnthropometrics)
+                          },
+                      icon: const Icon(Icons.add))
+                ],
+              ),
+              SizedBox(
+                  height: 200,
+                  child: ListView.builder(
+                      itemCount: respondent.anthropometrics.length,
+                      itemBuilder: (context, index) {
+                        final anthropometrics =
+                            respondent.anthropometrics[index];
+                        return Card(
+                          child: ListTile(
+                            title: Text(anthropometrics.date != null
+                                ? anthropometrics.date.toString()
+                                : 'No date'),
+                          ),
+                        );
+                      })),
+              const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Divider(),
+              ),
+              Row(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.all(8.0),
                     child: Icon(Icons.info),
                   ),
                   Text('Collections',

--- a/lib/household/view/view_respondent.dart
+++ b/lib/household/view/view_respondent.dart
@@ -64,6 +64,20 @@ class ViewRespondentPage extends StatelessWidget {
                             title: Text(anthropometrics.date != null
                                 ? anthropometrics.date.toString()
                                 : 'No date'),
+                            onTap: () => {
+                              Navigator.pushNamed(
+                                  context, PageRouter.viewAnthropometrics,
+                                  arguments: {'index': index})
+                            },
+                            onLongPress: () => showModalBottomSheet(
+                                context: context,
+                                builder: (context) {
+                                  return AnthropometricsOptions(
+                                      index: index,
+                                      date: anthropometrics.date != null
+                                          ? anthropometrics.date.toString()
+                                          : 'No date');
+                                }),
                           ),
                         );
                       })),

--- a/lib/household/widgets/container.dart
+++ b/lib/household/widgets/container.dart
@@ -100,6 +100,10 @@ Route _onGenerateRoute(RouteSettings settings) {
     case PageRouter.createAnthropometrics:
       page = const CreateAnthropometricsPage();
       break;
+    case PageRouter.viewAnthropometrics:
+      final args = settings.arguments as Map<String, dynamic>;
+      page = ViewAnthropometricsPage(index: args['index']);
+      break;
     default:
       throw Exception('Invalid route: ${settings.name}');
   }

--- a/lib/household/widgets/container.dart
+++ b/lib/household/widgets/container.dart
@@ -97,6 +97,9 @@ Route _onGenerateRoute(RouteSettings settings) {
     case PageRouter.thirdPassHelp:
       page = const ThirdPassHelpPage();
       break;
+    case PageRouter.createAnthropometrics:
+      page = const CreateAnthropometricsPage();
+      break;
     default:
       throw Exception('Invalid route: ${settings.name}');
   }

--- a/lib/navigation/models/page_router.dart
+++ b/lib/navigation/models/page_router.dart
@@ -34,6 +34,7 @@ class PageRouter {
   static const viewRespondent = 'viewrespondent';
   static const editRespondent = 'editrespondent';
   static const createAnthropometrics = 'createanthropometrics';
+  static const viewAnthropometrics = 'viewanthropometrics';
 
   static Route route(RouteSettings routeSettings) {
     switch (routeSettings.name) {

--- a/lib/navigation/models/page_router.dart
+++ b/lib/navigation/models/page_router.dart
@@ -33,6 +33,7 @@ class PageRouter {
   static const createRespondent = 'createrespondent';
   static const viewRespondent = 'viewrespondent';
   static const editRespondent = 'editrespondent';
+  static const createAnthropometrics = 'createanthropometrics';
 
   static Route route(RouteSettings routeSettings) {
     switch (routeSettings.name) {

--- a/packages/gibsonify_api/lib/src/models/anthropometrics.dart
+++ b/packages/gibsonify_api/lib/src/models/anthropometrics.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+import 'package:isar/isar.dart';
+
+part 'anthropometrics.g.dart';
+
+@Embedded(inheritance: false)
+class Anthropometrics extends Equatable {
+  Anthropometrics({
+    this.date,
+    this.weight,
+    this.height,
+    this.waist,
+    this.armLength,
+    this.handSpan,
+  });
+
+  final DateTime? date;
+  final double? height;
+  final double? weight;
+  final double? waist;
+  final double? armLength;
+  final double? handSpan;
+
+  @override
+  @ignore
+  List<Object?> get props => [
+        date,
+        height,
+        weight,
+        waist,
+        armLength,
+        handSpan,
+      ];
+}

--- a/packages/gibsonify_api/lib/src/models/anthropometrics.g.dart
+++ b/packages/gibsonify_api/lib/src/models/anthropometrics.g.dart
@@ -1,0 +1,615 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'anthropometrics.dart';
+
+// **************************************************************************
+// IsarEmbeddedGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters
+
+const AnthropometricsSchema = Schema(
+  name: r'Anthropometrics',
+  id: -2851607001850966851,
+  properties: {
+    r'armLength': PropertySchema(
+      id: 0,
+      name: r'armLength',
+      type: IsarType.double,
+    ),
+    r'date': PropertySchema(
+      id: 1,
+      name: r'date',
+      type: IsarType.dateTime,
+    ),
+    r'handSpan': PropertySchema(
+      id: 2,
+      name: r'handSpan',
+      type: IsarType.double,
+    ),
+    r'height': PropertySchema(
+      id: 3,
+      name: r'height',
+      type: IsarType.double,
+    ),
+    r'waist': PropertySchema(
+      id: 4,
+      name: r'waist',
+      type: IsarType.double,
+    ),
+    r'weight': PropertySchema(
+      id: 5,
+      name: r'weight',
+      type: IsarType.double,
+    )
+  },
+  estimateSize: _anthropometricsEstimateSize,
+  serialize: _anthropometricsSerialize,
+  deserialize: _anthropometricsDeserialize,
+  deserializeProp: _anthropometricsDeserializeProp,
+);
+
+int _anthropometricsEstimateSize(
+  Anthropometrics object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  return bytesCount;
+}
+
+void _anthropometricsSerialize(
+  Anthropometrics object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeDouble(offsets[0], object.armLength);
+  writer.writeDateTime(offsets[1], object.date);
+  writer.writeDouble(offsets[2], object.handSpan);
+  writer.writeDouble(offsets[3], object.height);
+  writer.writeDouble(offsets[4], object.waist);
+  writer.writeDouble(offsets[5], object.weight);
+}
+
+Anthropometrics _anthropometricsDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = Anthropometrics(
+    armLength: reader.readDoubleOrNull(offsets[0]),
+    date: reader.readDateTimeOrNull(offsets[1]),
+    handSpan: reader.readDoubleOrNull(offsets[2]),
+    height: reader.readDoubleOrNull(offsets[3]),
+    waist: reader.readDoubleOrNull(offsets[4]),
+    weight: reader.readDoubleOrNull(offsets[5]),
+  );
+  return object;
+}
+
+P _anthropometricsDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 1:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 2:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 3:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 4:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 5:
+      return (reader.readDoubleOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+extension AnthropometricsQueryFilter
+    on QueryBuilder<Anthropometrics, Anthropometrics, QFilterCondition> {
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      armLengthIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'armLength',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      armLengthIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'armLength',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      armLengthEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'armLength',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      armLengthGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'armLength',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      armLengthLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'armLength',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      armLengthBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'armLength',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      dateIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'date',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      dateIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'date',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      dateEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'date',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      dateGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'date',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      dateLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'date',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      dateBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'date',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      handSpanIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'handSpan',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      handSpanIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'handSpan',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      handSpanEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'handSpan',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      handSpanGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'handSpan',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      handSpanLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'handSpan',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      handSpanBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'handSpan',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      heightIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'height',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      heightIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'height',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      heightEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'height',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      heightGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'height',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      heightLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'height',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      heightBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'height',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      waistIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'waist',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      waistIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'waist',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      waistEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'waist',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      waistGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'waist',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      waistLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'waist',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      waistBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'waist',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      weightIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'weight',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      weightIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'weight',
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      weightEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'weight',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      weightGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'weight',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      weightLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'weight',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Anthropometrics, Anthropometrics, QAfterFilterCondition>
+      weightBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'weight',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+}
+
+extension AnthropometricsQueryObject
+    on QueryBuilder<Anthropometrics, Anthropometrics, QFilterCondition> {}

--- a/packages/gibsonify_api/lib/src/models/household.g.dart
+++ b/packages/gibsonify_api/lib/src/models/household.g.dart
@@ -73,7 +73,8 @@ const HouseholdSchema = CollectionSchema(
     r'Recipe': RecipeSchema,
     r'Ingredient': IngredientSchema,
     r'Probe': ProbeSchema,
-    r'ProbeOption': ProbeOptionSchema
+    r'ProbeOption': ProbeOptionSchema,
+    r'Anthropometrics': AnthropometricsSchema
   },
   getId: _householdGetId,
   getLinks: _householdGetLinks,

--- a/packages/gibsonify_api/lib/src/models/models.dart
+++ b/packages/gibsonify_api/lib/src/models/models.dart
@@ -7,3 +7,4 @@ export 'recipe.dart';
 export 'login_info.dart';
 export 'household.dart';
 export 'respondent.dart';
+export 'anthropometrics.dart';

--- a/packages/gibsonify_api/lib/src/models/respondent.dart
+++ b/packages/gibsonify_api/lib/src/models/respondent.dart
@@ -1,3 +1,4 @@
+import 'package:gibsonify_api/src/models/anthropometrics.dart';
 import 'package:gibsonify_api/src/models/gibsons_form.dart';
 import 'package:isar/isar.dart';
 
@@ -9,12 +10,14 @@ class Respondent {
   final String phoneNumber;
   final String comments;
   final List<GibsonsForm> collections;
+  final List<Anthropometrics> anthropometrics;
 
   Respondent({
     this.name = "",
     this.phoneNumber = "",
     this.comments = "",
     this.collections = const [],
+    this.anthropometrics = const [],
   });
 
   Respondent copyWith({
@@ -22,12 +25,14 @@ class Respondent {
     String? phoneNumber,
     String? comments,
     List<GibsonsForm>? collections,
+    List<Anthropometrics>? anthropometrics,
   }) {
     return Respondent(
       name: name ?? this.name,
       phoneNumber: phoneNumber ?? this.phoneNumber,
       comments: comments ?? this.comments,
       collections: collections ?? this.collections,
+      anthropometrics: anthropometrics ?? this.anthropometrics,
     );
   }
 }

--- a/packages/gibsonify_api/lib/src/models/respondent.g.dart
+++ b/packages/gibsonify_api/lib/src/models/respondent.g.dart
@@ -13,24 +13,30 @@ const RespondentSchema = Schema(
   name: r'Respondent',
   id: -2873524172455157742,
   properties: {
-    r'collections': PropertySchema(
+    r'anthropometrics': PropertySchema(
       id: 0,
+      name: r'anthropometrics',
+      type: IsarType.objectList,
+      target: r'Anthropometrics',
+    ),
+    r'collections': PropertySchema(
+      id: 1,
       name: r'collections',
       type: IsarType.objectList,
       target: r'GibsonsForm',
     ),
     r'comments': PropertySchema(
-      id: 1,
+      id: 2,
       name: r'comments',
       type: IsarType.string,
     ),
     r'name': PropertySchema(
-      id: 2,
+      id: 3,
       name: r'name',
       type: IsarType.string,
     ),
     r'phoneNumber': PropertySchema(
-      id: 3,
+      id: 4,
       name: r'phoneNumber',
       type: IsarType.string,
     )
@@ -47,6 +53,15 @@ int _respondentEstimateSize(
   Map<Type, List<int>> allOffsets,
 ) {
   var bytesCount = offsets.last;
+  bytesCount += 3 + object.anthropometrics.length * 3;
+  {
+    final offsets = allOffsets[Anthropometrics]!;
+    for (var i = 0; i < object.anthropometrics.length; i++) {
+      final value = object.anthropometrics[i];
+      bytesCount +=
+          AnthropometricsSchema.estimateSize(value, offsets, allOffsets);
+    }
+  }
   bytesCount += 3 + object.collections.length * 3;
   {
     final offsets = allOffsets[GibsonsForm]!;
@@ -67,15 +82,21 @@ void _respondentSerialize(
   List<int> offsets,
   Map<Type, List<int>> allOffsets,
 ) {
-  writer.writeObjectList<GibsonsForm>(
+  writer.writeObjectList<Anthropometrics>(
     offsets[0],
+    allOffsets,
+    AnthropometricsSchema.serialize,
+    object.anthropometrics,
+  );
+  writer.writeObjectList<GibsonsForm>(
+    offsets[1],
     allOffsets,
     GibsonsFormSchema.serialize,
     object.collections,
   );
-  writer.writeString(offsets[1], object.comments);
-  writer.writeString(offsets[2], object.name);
-  writer.writeString(offsets[3], object.phoneNumber);
+  writer.writeString(offsets[2], object.comments);
+  writer.writeString(offsets[3], object.name);
+  writer.writeString(offsets[4], object.phoneNumber);
 }
 
 Respondent _respondentDeserialize(
@@ -85,16 +106,23 @@ Respondent _respondentDeserialize(
   Map<Type, List<int>> allOffsets,
 ) {
   final object = Respondent(
-    collections: reader.readObjectList<GibsonsForm>(
+    anthropometrics: reader.readObjectList<Anthropometrics>(
           offsets[0],
+          AnthropometricsSchema.deserialize,
+          allOffsets,
+          Anthropometrics(),
+        ) ??
+        const [],
+    collections: reader.readObjectList<GibsonsForm>(
+          offsets[1],
           GibsonsFormSchema.deserialize,
           allOffsets,
           GibsonsForm(),
         ) ??
         const [],
-    comments: reader.readStringOrNull(offsets[1]) ?? "",
-    name: reader.readStringOrNull(offsets[2]) ?? "",
-    phoneNumber: reader.readStringOrNull(offsets[3]) ?? "",
+    comments: reader.readStringOrNull(offsets[2]) ?? "",
+    name: reader.readStringOrNull(offsets[3]) ?? "",
+    phoneNumber: reader.readStringOrNull(offsets[4]) ?? "",
   );
   return object;
 }
@@ -107,6 +135,14 @@ P _respondentDeserializeProp<P>(
 ) {
   switch (propertyId) {
     case 0:
+      return (reader.readObjectList<Anthropometrics>(
+            offset,
+            AnthropometricsSchema.deserialize,
+            allOffsets,
+            Anthropometrics(),
+          ) ??
+          const []) as P;
+    case 1:
       return (reader.readObjectList<GibsonsForm>(
             offset,
             GibsonsFormSchema.deserialize,
@@ -114,11 +150,11 @@ P _respondentDeserializeProp<P>(
             GibsonsForm(),
           ) ??
           const []) as P;
-    case 1:
-      return (reader.readStringOrNull(offset) ?? "") as P;
     case 2:
       return (reader.readStringOrNull(offset) ?? "") as P;
     case 3:
+      return (reader.readStringOrNull(offset) ?? "") as P;
+    case 4:
       return (reader.readStringOrNull(offset) ?? "") as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -127,6 +163,95 @@ P _respondentDeserializeProp<P>(
 
 extension RespondentQueryFilter
     on QueryBuilder<Respondent, Respondent, QFilterCondition> {
+  QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
+      anthropometricsLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'anthropometrics',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
+      anthropometricsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'anthropometrics',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
+      anthropometricsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'anthropometrics',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
+      anthropometricsLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'anthropometrics',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
+      anthropometricsLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'anthropometrics',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
+      anthropometricsLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'anthropometrics',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+
   QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
       collectionsLengthEqualTo(int length) {
     return QueryBuilder.apply(this, (query) {
@@ -619,6 +744,13 @@ extension RespondentQueryFilter
 
 extension RespondentQueryObject
     on QueryBuilder<Respondent, Respondent, QFilterCondition> {
+  QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
+      anthropometricsElement(FilterQuery<Anthropometrics> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.object(q, r'anthropometrics');
+    });
+  }
+
   QueryBuilder<Respondent, Respondent, QAfterFilterCondition>
       collectionsElement(FilterQuery<GibsonsForm> q) {
     return QueryBuilder.apply(this, (query) {


### PR DESCRIPTION
Adds anthropometric data collection (separate to nutritional data collection) at the `Respondent` level, with new create/view screens and schemas.

Five typical measurements have been added in this PR - weight, height, arm length, hand span, waist. Further measurements can be very easily added if required.

~~**PR depends on #57. Only merge into `main` after #57 has been merged.**~~