### PR TITLE
ci(create_and_build_release): fix trigger on branch create

### DIFF
--- a/.github/workflows/create_and_build_release.yml
+++ b/.github/workflows/create_and_build_release.yml
@@ -1,6 +1,6 @@
 name: create_and_build_release
 on:
-  create:
+  push:
     tags:
       - "*" # Will trigger for every tag, alternative: 'v*'
 


### PR DESCRIPTION
The `create_and_build_release` job was unintentionally being triggered (and failing) on new branch pushes (e.g. https://github.com/DigitalNutritionalAssessment/gibsonify/actions/runs/4049574696). Changing the trigger from `create:` to `push: tags` should fix this.