### PR TITLE
feat: survey parameters validation

### DIFF
--- a/lib/collection/widgets/sensitization_screen.dart
+++ b/lib/collection/widgets/sensitization_screen.dart
@@ -73,39 +73,50 @@ class SurveyInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SurveysBloc, SurveysState>(
       builder: (context, surveysState) {
-        return BlocBuilder<CollectionBloc, CollectionState>(
-          builder: (context, collectionState) {
-            return DropdownSearch<String>(
-              popupProps: const PopupProps.menu(
-                  showSelectedItems: true,
-                  fit: FlexFit.loose,
-                  constraints: BoxConstraints.tightFor()),
-              dropdownDecoratorProps: DropDownDecoratorProps(
-                dropdownSearchDecoration: InputDecoration(
-                    icon: const Icon(Icons.assignment),
-                    labelText: "Survey ID",
-                    helperText:
-                        'The survey under which this interview is being performed',
-                    // TODO: the errorText should be displayed if nothing is chosen
-                    // so investigate how this can be achieved with focusnodes or
-                    // maybe send an empty string (although that would not work all
-                    // the time), currently the errorText is never shown
-                    errorText: isFieldModifiedAndEmpty(
-                            collectionState.gibsonsForm.surveyId)
-                        ? 'Select survey'
-                        : null),
-              ),
-              items: surveysState.surveys
-                  .map((survey) => survey.surveyId)
-                  .toList(),
-              onChanged: (surveyId) {
-                if (surveyId != null) {
-                  context
-                      .read<CollectionBloc>()
-                      .add(SurveyChanged(surveyId: surveyId));
-                }
+        return BlocBuilder<HouseholdBloc, HouseholdState>(
+          builder: (context, householdState) {
+            return BlocBuilder<CollectionBloc, CollectionState>(
+              builder: (context, collectionState) {
+                return DropdownSearch<String>(
+                  popupProps: const PopupProps.menu(
+                      showSelectedItems: true,
+                      fit: FlexFit.loose,
+                      constraints: BoxConstraints.tightFor()),
+                  dropdownDecoratorProps: DropDownDecoratorProps(
+                    dropdownSearchDecoration: InputDecoration(
+                        icon: const Icon(Icons.assignment),
+                        labelText: "Survey ID",
+                        helperText:
+                            'The survey under which this interview is being performed',
+                        // TODO: the errorText should be displayed if nothing is chosen
+                        // so investigate how this can be achieved with focusnodes or
+                        // maybe send an empty string (although that would not work all
+                        // the time), currently the errorText is never shown
+                        errorText: isFieldModifiedAndEmpty(
+                                collectionState.gibsonsForm.surveyId)
+                            ? 'Select survey'
+                            : null),
+                  ),
+                  items: surveysState.surveys
+                      // The below filter hides any surveys with parameters that make
+                      // the respondent/household ineligible. Maybe this should be more explicit?
+                      .where((survey) => survey
+                          .checkParameters(
+                              respondent: householdState.household!.respondents[
+                                  householdState.selectedRespondentIndex!])
+                          .isEmpty)
+                      .map((survey) => survey.surveyId)
+                      .toList(),
+                  onChanged: (surveyId) {
+                    if (surveyId != null) {
+                      context
+                          .read<CollectionBloc>()
+                          .add(SurveyChanged(surveyId: surveyId));
+                    }
+                  },
+                  selectedItem: collectionState.gibsonsForm.surveyId,
+                );
               },
-              selectedItem: collectionState.gibsonsForm.surveyId,
             );
           },
         );

--- a/lib/collection/widgets/sensitization_screen.dart
+++ b/lib/collection/widgets/sensitization_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:gibsonify/household/household.dart';
 import 'package:gibsonify/surveys/surveys.dart';
 import 'package:intl/intl.dart';
@@ -310,11 +311,18 @@ List<String> checkSurveyParameters(
     {required Survey survey,
     required Household household,
     required Respondent respondent}) {
-  // TODO: add household location check
-
   final errors = <String>[];
   final respondentAge =
       DateTime.now().difference(respondent.dateOfBirth!).inDays / 365;
+  final householdLatLon =
+      household.geoLocation.split(',').map(double.parse).toList();
+  final surveyArea = survey.getArea();
+
+  if (Geolocator.distanceBetween(surveyArea.center.latitude,
+          surveyArea.center.longitude, householdLatLon[0], householdLatLon[1]) >
+      surveyArea.radius) {
+    errors.add('Household is outside survey area.');
+  }
 
   if (respondentAge < survey.minAge) {
     errors.add('Respondent is too young.');

--- a/lib/collection/widgets/sensitization_screen.dart
+++ b/lib/collection/widgets/sensitization_screen.dart
@@ -100,8 +100,9 @@ class SurveyInput extends StatelessWidget {
                   items: surveysState.surveys
                       // The below filter hides any surveys with parameters that make
                       // the respondent/household ineligible. Maybe this should be more explicit?
-                      .where((survey) => survey
-                          .checkParameters(
+                      .where((survey) => checkSurveyParameters(
+                              survey: survey,
+                              household: householdState.household!,
                               respondent: householdState.household!.respondents[
                                   householdState.selectedRespondentIndex!])
                           .isEmpty)
@@ -303,4 +304,29 @@ class PhysioStatusInput extends StatelessWidget {
       },
     );
   }
+}
+
+List<String> checkSurveyParameters(
+    {required Survey survey,
+    required Household household,
+    required Respondent respondent}) {
+  // TODO: add household location check
+
+  final errors = <String>[];
+  final respondentAge =
+      DateTime.now().difference(respondent.dateOfBirth!).inDays / 365;
+
+  if (respondentAge < survey.minAge) {
+    errors.add('Respondent is too young.');
+  }
+
+  if (survey.maxAge != 100 && respondentAge > survey.maxAge) {
+    errors.add('Respondent is too old.');
+  }
+
+  if (survey.requiredSex != null && respondent.sex != survey.requiredSex) {
+    errors.add('Respondent must be ${survey.requiredSex!.name}.');
+  }
+
+  return errors;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
 
 import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:gibsonify_repository/gibsonify_repository.dart';
@@ -15,6 +16,13 @@ void main() async {
 
   final gibsonifyRepository = GibsonifyRepository(gibsonifyApi: gibsonifyApi);
   final isarRepository = await IsarRepository.create();
+
+  FlutterMapTileCaching.initialise(await RootDirectory.normalCache,
+      settings: FMTCSettings(
+          defaultTileProviderSettings: FMTCTileProviderSettings(
+              cachedValidDuration: const Duration(days: 365))));
+  final store = FMTC.instance('default');
+  await store.manage.createAsync();
 
   runApp(App(
       gibsonifyRepository: gibsonifyRepository,

--- a/lib/surveys/view/create_survey.dart
+++ b/lib/surveys/view/create_survey.dart
@@ -1,3 +1,4 @@
+import 'package:country_picker/country_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
@@ -94,6 +95,14 @@ class CreateSurveyScreen extends StatelessWidget {
                         validator: FormBuilderValidators.required()),
                     FormBuilderTextField(
                         name: 'country',
+                        readOnly: true,
+                        onTap: () => showCountryPicker(
+                            context: context,
+                            favorite: ['IN', 'GB'],
+                            onSelect: (Country country) {
+                              formKey.currentState!.fields['country']!
+                                  .didChange(country.name);
+                            }),
                         textCapitalization: TextCapitalization.sentences,
                         decoration: const InputDecoration(
                             label: Text('Country'), icon: Icon(Icons.flag)),

--- a/lib/surveys/view/create_survey.dart
+++ b/lib/surveys/view/create_survey.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
+import 'package:intl/intl.dart';
 
 class CreateSurveyScreen extends StatelessWidget {
   final List<String> surveyIds;
@@ -52,15 +53,26 @@ class CreateSurveyScreen extends StatelessWidget {
                             Navigator.pop(
                                 context,
                                 Survey(
-                                    surveyId:
-                                        formKey.currentState!.value['surveyId'],
-                                    name: formKey.currentState!.value['name'],
-                                    country:
-                                        formKey.currentState!.value['country'],
-                                    description: formKey
-                                        .currentState!.value['description'],
-                                    comments: formKey
-                                        .currentState!.value['comments']))
+                                  surveyId:
+                                      formKey.currentState!.value['surveyId'],
+                                  name: formKey.currentState!.value['name'],
+                                  country:
+                                      formKey.currentState!.value['country'],
+                                  description: formKey
+                                      .currentState!.value['description'],
+                                  comments:
+                                      formKey.currentState!.value['comments'],
+                                  requiredSex: formKey
+                                      .currentState!.value['requiredSex'],
+                                  minAge: (formKey.currentState!
+                                          .value['minMaxAge'] as RangeValues)
+                                      .start
+                                      .toInt(),
+                                  maxAge: (formKey.currentState!
+                                          .value['minMaxAge'] as RangeValues)
+                                      .end
+                                      .toInt(),
+                                ))
                           }
                       },
                   icon: const Icon(Icons.save))
@@ -70,61 +82,92 @@ class CreateSurveyScreen extends StatelessWidget {
               padding: const EdgeInsets.all(8.0),
               child: FormBuilder(
                 key: formKey,
-                child: Column(
-                  children: [
-                    FormBuilderTextField(
-                        name: 'surveyId',
-                        textCapitalization: TextCapitalization.characters,
-                        decoration: const InputDecoration(
-                            label: Text('Survey ID'), icon: Icon(Icons.list)),
-                        onChanged: (value) => changed = true,
-                        validator: FormBuilderValidators.compose([
-                          FormBuilderValidators.required(),
-                          FormBuilderValidators.minLength(4,
-                              errorText: 'Must be at least 4 characters'),
-                          (id) => surveyIds.contains(id)
-                              ? 'Survey with this ID already exists'
-                              : null
-                        ])),
-                    FormBuilderTextField(
-                        name: 'name',
-                        textCapitalization: TextCapitalization.words,
-                        decoration: const InputDecoration(
-                            label: Text('Name'), icon: Icon(Icons.label)),
-                        onChanged: (value) => changed = true,
-                        validator: FormBuilderValidators.required()),
-                    FormBuilderTextField(
-                        name: 'country',
-                        readOnly: true,
-                        onTap: () => showCountryPicker(
-                            context: context,
-                            favorite: ['IN', 'GB'],
-                            onSelect: (Country country) {
-                              formKey.currentState!.fields['country']!
-                                  .didChange(country.name);
-                            }),
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      FormBuilderTextField(
+                          name: 'surveyId',
+                          textCapitalization: TextCapitalization.characters,
+                          decoration: const InputDecoration(
+                              label: Text('Survey ID'), icon: Icon(Icons.list)),
+                          onChanged: (value) => changed = true,
+                          validator: FormBuilderValidators.compose([
+                            FormBuilderValidators.required(),
+                            FormBuilderValidators.minLength(4,
+                                errorText: 'Must be at least 4 characters'),
+                            (id) => surveyIds.contains(id)
+                                ? 'Survey with this ID already exists'
+                                : null
+                          ])),
+                      FormBuilderTextField(
+                          name: 'name',
+                          textCapitalization: TextCapitalization.words,
+                          decoration: const InputDecoration(
+                              label: Text('Name'), icon: Icon(Icons.label)),
+                          onChanged: (value) => changed = true,
+                          validator: FormBuilderValidators.required()),
+                      FormBuilderTextField(
+                          name: 'country',
+                          readOnly: true,
+                          onTap: () => showCountryPicker(
+                              context: context,
+                              favorite: ['IN', 'GB'],
+                              onSelect: (Country country) {
+                                formKey.currentState!.fields['country']!
+                                    .didChange(country.name);
+                              }),
+                          textCapitalization: TextCapitalization.sentences,
+                          decoration: const InputDecoration(
+                              label: Text('Country'), icon: Icon(Icons.flag)),
+                          onChanged: (value) => changed = true,
+                          validator: FormBuilderValidators.required()),
+                      FormBuilderTextField(
+                        name: 'description',
                         textCapitalization: TextCapitalization.sentences,
                         decoration: const InputDecoration(
-                            label: Text('Country'), icon: Icon(Icons.flag)),
+                            label: Text('Description'), icon: Icon(Icons.info)),
                         onChanged: (value) => changed = true,
-                        validator: FormBuilderValidators.required()),
-                    FormBuilderTextField(
-                      name: 'description',
-                      textCapitalization: TextCapitalization.sentences,
-                      decoration: const InputDecoration(
-                          label: Text('Description'), icon: Icon(Icons.info)),
-                      onChanged: (value) => changed = true,
-                    ),
-                    FormBuilderTextField(
-                      name: 'comments',
-                      textCapitalization: TextCapitalization.sentences,
-                      minLines: 1,
-                      maxLines: null,
-                      decoration: const InputDecoration(
-                          label: Text('Comments'), icon: Icon(Icons.message)),
-                      onChanged: (value) => changed = true,
-                    ),
-                  ],
+                      ),
+                      FormBuilderTextField(
+                        name: 'comments',
+                        textCapitalization: TextCapitalization.sentences,
+                        minLines: 1,
+                        maxLines: null,
+                        decoration: const InputDecoration(
+                            label: Text('Comments'), icon: Icon(Icons.message)),
+                        onChanged: (value) => changed = true,
+                      ),
+                      const Divider(),
+                      FormBuilderDropdown(
+                        name: 'requiredSex',
+                        decoration: const InputDecoration(
+                          label: Text('Respondent Sex'),
+                          icon: Icon(Icons.wc),
+                        ),
+                        onChanged: (value) => changed = true,
+                        items: Sex.values
+                            .map((sex) => DropdownMenuItem(
+                                value: sex,
+                                child:
+                                    Text(toBeginningOfSentenceCase(sex.name)!)))
+                            .toList(),
+                      ),
+                      FormBuilderRangeSlider(
+                        name: 'minMaxAge',
+                        min: 0,
+                        max: 100,
+                        divisions: 100,
+                        decoration: const InputDecoration(
+                          label: Text('Respondent Age'),
+                          icon: Icon(Icons.person),
+                        ),
+                        initialValue: const RangeValues(0, 100),
+                        validator: (value) => value!.start >= value.end
+                            ? 'Maximum age must exceed minimum age'
+                            : null,
+                      )
+                    ],
+                  ),
                 ),
               ))),
     );

--- a/lib/surveys/view/create_survey.dart
+++ b/lib/surveys/view/create_survey.dart
@@ -2,6 +2,7 @@ import 'package:country_picker/country_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:gibsonify/surveys/surveys.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:intl/intl.dart';
 
@@ -72,6 +73,8 @@ class CreateSurveyScreen extends StatelessWidget {
                                           .value['minMaxAge'] as RangeValues)
                                       .end
                                       .toInt(),
+                                  geoArea:
+                                      formKey.currentState!.value['geoArea'],
                                 ))
                           }
                       },
@@ -138,6 +141,25 @@ class CreateSurveyScreen extends StatelessWidget {
                         onChanged: (value) => changed = true,
                       ),
                       const Divider(),
+                      FormBuilderTextField(
+                          name: 'geoArea',
+                          readOnly: true,
+                          onTap: () async {
+                            Area? area = await Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => SelectAreaScreen()));
+
+                            if (area != null) {
+                              formKey.currentState!.fields['geoArea']!.didChange(
+                                  "${area.center.latitude},${area.center.longitude},${area.radius},${area.zoom}");
+                            }
+                          },
+                          decoration: const InputDecoration(
+                              label: Text('Geographical Area'),
+                              icon: Icon(Icons.place)),
+                          onChanged: (value) => changed = true,
+                          validator: FormBuilderValidators.required()),
                       FormBuilderDropdown(
                         name: 'requiredSex',
                         decoration: const InputDecoration(

--- a/lib/surveys/view/select_area.dart
+++ b/lib/surveys/view/select_area.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:latlong2/latlong.dart';
@@ -53,6 +54,7 @@ class SelectAreaScreen extends StatelessWidget {
             ],
             children: [
               TileLayer(
+                tileProvider: FMTC.instance('default').getTileProvider(),
                 urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 userAgentPackageName: 'org.gibsonify.gibsonify',
               ),

--- a/lib/surveys/view/select_area.dart
+++ b/lib/surveys/view/select_area.dart
@@ -1,16 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:url_launcher/url_launcher.dart';
-
-class Area {
-  final LatLng center;
-  final int radius;
-  final double zoom;
-
-  Area(this.center, this.radius, this.zoom);
-}
 
 class SelectAreaScreen extends StatelessWidget {
   SelectAreaScreen({Key? key}) : super(key: key);

--- a/lib/surveys/view/select_area.dart
+++ b/lib/surveys/view/select_area.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class Area {
+  final LatLng center;
+  final int radius;
+  final double zoom;
+
+  Area(this.center, this.radius, this.zoom);
+}
+
+class SelectAreaScreen extends StatelessWidget {
+  SelectAreaScreen({Key? key}) : super(key: key);
+
+  final MapController _mapController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final circleDia = MediaQuery.of(context).size.width * 0.8;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select area'),
+        actions: [
+          IconButton(
+            onPressed: () {
+              final center = _mapController.center;
+              final centerPoint = _mapController.latLngToScreenPoint(center);
+              final zoom = _mapController.zoom;
+
+              final boundary = _mapController.pointToLatLng(
+                  CustomPoint(centerPoint!.x, centerPoint.y + circleDia / 2));
+              final distance = Geolocator.distanceBetween(center.latitude,
+                  center.longitude, boundary!.latitude, boundary.longitude);
+              Navigator.pop(context, Area(center, distance.toInt(), zoom));
+            },
+            icon: const Icon(Icons.check),
+          ),
+        ],
+      ),
+      body: Stack(
+        alignment: Alignment.center,
+        children: [
+          FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+                center: LatLng(20.8, 78.5),
+                zoom: 4.6,
+                interactiveFlags:
+                    InteractiveFlag.all & ~InteractiveFlag.rotate),
+            nonRotatedChildren: [
+              AttributionWidget.defaultWidget(
+                source: '© OpenStreetMap',
+                onSourceTapped: () =>
+                    launchUrl(Uri.parse('https://openstreetmap.org/copyright')),
+              ),
+            ],
+            children: [
+              TileLayer(
+                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                userAgentPackageName: 'org.gibsonify.gibsonify',
+              ),
+            ],
+          ),
+          IgnorePointer(
+            child: Container(
+              width: circleDia,
+              height: circleDia,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: Colors.black),
+              ),
+            ),
+          ),
+          const IgnorePointer(
+            child: Padding(
+              padding: EdgeInsets.only(bottom: 12.0),
+              child: Icon(Icons.place, color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/surveys/view/view.dart
+++ b/lib/surveys/view/view.dart
@@ -3,3 +3,4 @@ export 'create_survey.dart';
 export 'view_survey.dart';
 export 'import_survey.dart';
 export 'select_area.dart';
+export 'view_area.dart';

--- a/lib/surveys/view/view.dart
+++ b/lib/surveys/view/view.dart
@@ -2,3 +2,4 @@ export 'surveys.dart';
 export 'create_survey.dart';
 export 'view_survey.dart';
 export 'import_survey.dart';
+export 'select_area.dart';

--- a/lib/surveys/view/view_area.dart
+++ b/lib/surveys/view/view_area.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -40,6 +41,7 @@ class ViewAreaScreen extends StatelessWidget {
             ],
             children: [
               TileLayer(
+                tileProvider: FMTC.instance('default').getTileProvider(),
                 urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 userAgentPackageName: 'org.gibsonify.gibsonify',
               ),

--- a/lib/surveys/view/view_area.dart
+++ b/lib/surveys/view/view_area.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:gibsonify/surveys/surveys.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class ViewAreaScreen extends StatelessWidget {
+  ViewAreaScreen({Key? key, required this.geoArea}) : super(key: key);
+  final String geoArea;
+  final MapController _mapController = MapController();
+
+  @override
+  Widget build(BuildContext context) {
+    final circleDia = MediaQuery.of(context).size.width * 0.8;
+    final vals = geoArea.split(',');
+    final center = LatLng(double.parse(vals[0]), double.parse(vals[1]));
+    final radius = int.parse(vals[2]);
+    final zoom = double.parse(vals[3]);
+    final area = Area(center, radius, zoom);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('View area'),
+      ),
+      body: Stack(
+        alignment: Alignment.center,
+        children: [
+          FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+                center: area.center,
+                zoom: area.zoom,
+                interactiveFlags: InteractiveFlag.none),
+            nonRotatedChildren: [
+              AttributionWidget.defaultWidget(
+                source: '© OpenStreetMap',
+                onSourceTapped: () =>
+                    launchUrl(Uri.parse('https://openstreetmap.org/copyright')),
+              ),
+            ],
+            children: [
+              TileLayer(
+                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                userAgentPackageName: 'org.gibsonify.gibsonify',
+              ),
+            ],
+          ),
+          IgnorePointer(
+            child: Container(
+              width: circleDia,
+              height: circleDia,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: Colors.black),
+              ),
+            ),
+          ),
+          const IgnorePointer(
+            child: Padding(
+              padding: EdgeInsets.only(bottom: 12.0),
+              child: Icon(Icons.place, color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/surveys/view/view_area.dart
+++ b/lib/surveys/view/view_area.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:gibsonify/surveys/surveys.dart';
+import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/surveys/view/view_survey.dart
+++ b/lib/surveys/view/view_survey.dart
@@ -77,6 +77,23 @@ class ViewSurveyScreen extends StatelessWidget {
                       ),
                       const Divider(),
                       FormBuilderTextField(
+                        name: 'geoArea',
+                        decoration: InputDecoration(
+                          label: const Text('Geographical Area'),
+                          icon: const Icon(Icons.place),
+                          suffixIcon: IconButton(
+                            icon: const Icon(Icons.map),
+                            onPressed: () => Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => ViewAreaScreen(
+                                        geoArea: survey.geoArea!))),
+                          ),
+                        ),
+                        initialValue: survey.geoArea!,
+                        readOnly: true,
+                      ),
+                      FormBuilderTextField(
                         name: 'requiredSex',
                         decoration: const InputDecoration(
                             label: Text('Respondent Sex'),

--- a/lib/surveys/view/view_survey.dart
+++ b/lib/surveys/view/view_survey.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:gibsonify/surveys/surveys.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
+import 'package:intl/intl.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 class ViewSurveyScreen extends StatelessWidget {
@@ -72,6 +73,33 @@ class ViewSurveyScreen extends StatelessWidget {
                         decoration: const InputDecoration(
                             label: Text('Comments'), icon: Icon(Icons.message)),
                         initialValue: survey.comments,
+                        enabled: false,
+                      ),
+                      const Divider(),
+                      FormBuilderTextField(
+                        name: 'requiredSex',
+                        decoration: const InputDecoration(
+                            label: Text('Respondent Sex'),
+                            icon: Icon(Icons.message)),
+                        initialValue: toBeginningOfSentenceCase(
+                                survey.requiredSex?.name) ??
+                            'Any',
+                        enabled: false,
+                      ),
+                      FormBuilderTextField(
+                        name: 'minAge',
+                        decoration: const InputDecoration(
+                            label: Text('Respondent Minimum Age'),
+                            icon: Icon(Icons.vertical_align_bottom)),
+                        initialValue: survey.minAge.toString(),
+                        enabled: false,
+                      ),
+                      FormBuilderTextField(
+                        name: 'maxAge',
+                        decoration: const InputDecoration(
+                            label: Text('Respondent Maximum Age'),
+                            icon: Icon(Icons.vertical_align_top)),
+                        initialValue: survey.maxAge.toString(),
                         enabled: false,
                       ),
                     ],

--- a/lib/surveys/view/view_survey.dart
+++ b/lib/surveys/view/view_survey.dart
@@ -120,6 +120,7 @@ class ShareSurvey extends StatelessWidget {
     return AlertDialog(
       title: const Text('Share survey'),
       content: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
           const Text(
               'Import this survey on another device by scanning the QR code below from the Gibsonify app.'),

--- a/packages/gibsonify_api/lib/src/models/survey.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.dart
@@ -1,8 +1,17 @@
 import 'package:equatable/equatable.dart';
 import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:isar/isar.dart';
+import 'package:latlong2/latlong.dart';
 
 part 'survey.g.dart';
+
+class Area {
+  final LatLng center;
+  final int radius;
+  final double zoom;
+
+  Area(this.center, this.radius, this.zoom);
+}
 
 @Collection(inheritance: false)
 class Survey extends Equatable {
@@ -103,4 +112,13 @@ class Survey extends Equatable {
         requiredSex,
         geoArea
       ];
+
+  Area getArea() {
+    final parts = geoArea!.split(',');
+    final center = LatLng(double.parse(parts[0]), double.parse(parts[1]));
+    final radius = int.parse(parts[2]);
+    final zoom = double.parse(parts[3]);
+
+    return Area(center, radius, zoom);
+  }
 }

--- a/packages/gibsonify_api/lib/src/models/survey.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.dart
@@ -96,4 +96,26 @@ class Survey extends Equatable {
         maxAge,
         requiredSex
       ];
+
+  List<String> checkParameters({required Respondent respondent}) {
+    // TODO: add household location check
+
+    final errors = <String>[];
+    final respondentAge =
+        DateTime.now().difference(respondent.dateOfBirth!).inDays / 365;
+
+    if (respondentAge < minAge) {
+      errors.add('Respondent is too young.');
+    }
+
+    if (maxAge != 100 && respondentAge > maxAge) {
+      errors.add('Respondent is too old.');
+    }
+
+    if (requiredSex != null && respondent.sex != requiredSex) {
+      errors.add('Respondent must be ${requiredSex!.name}.');
+    }
+
+    return errors;
+  }
 }

--- a/packages/gibsonify_api/lib/src/models/survey.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.dart
@@ -60,11 +60,18 @@ class Survey extends Equatable {
       'comments': comments,
       'minAge': minAge,
       'maxAge': maxAge,
-      'requiredSex': requiredSex
+      'requiredSex': requiredSex?.name
     };
   }
 
   factory Survey.fromJson(Map<String, dynamic> json) {
+    Sex? requiredSex;
+
+    if (json['requiredSex'] != null) {
+      requiredSex = Sex.values
+          .singleWhere((element) => element.name == json['requiredSex']);
+    }
+
     return Survey(
         surveyId: json['surveyId'],
         name: json['name'],
@@ -73,7 +80,7 @@ class Survey extends Equatable {
         comments: json['comments'],
         minAge: json['minAge'],
         maxAge: json['maxAge'],
-        requiredSex: json['requiredSex']);
+        requiredSex: requiredSex);
   }
 
   @override

--- a/packages/gibsonify_api/lib/src/models/survey.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.dart
@@ -13,8 +13,8 @@ class Survey extends Equatable {
   final String country;
   final String? description;
   final String? comments;
-  final int? minAge;
-  final int? maxAge;
+  final int minAge;
+  final int maxAge;
   @Enumerated(EnumType.ordinal32)
   final Sex? requiredSex;
 
@@ -25,8 +25,8 @@ class Survey extends Equatable {
       required this.country,
       this.description,
       this.comments,
-      this.minAge,
-      this.maxAge,
+      required this.minAge,
+      required this.maxAge,
       this.requiredSex});
 
   Survey copyWith(

--- a/packages/gibsonify_api/lib/src/models/survey.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:gibsonify_api/gibsonify_api.dart';
 import 'package:isar/isar.dart';
 
 part 'survey.g.dart';
@@ -12,6 +13,10 @@ class Survey extends Equatable {
   final String country;
   final String? description;
   final String? comments;
+  final int? minAge;
+  final int? maxAge;
+  @Enumerated(EnumType.ordinal32)
+  final Sex? requiredSex;
 
   Survey(
       {this.id = Isar.autoIncrement,
@@ -19,7 +24,10 @@ class Survey extends Equatable {
       required this.name,
       required this.country,
       this.description,
-      this.comments});
+      this.comments,
+      this.minAge,
+      this.maxAge,
+      this.requiredSex});
 
   Survey copyWith(
       {Id? id,
@@ -27,14 +35,20 @@ class Survey extends Equatable {
       String? name,
       String? country,
       String? description,
-      String? comments}) {
+      String? comments,
+      int? minAge,
+      int? maxAge,
+      Sex? requiredSex}) {
     return Survey(
         id: id ?? this.id,
         surveyId: surveyId ?? this.surveyId,
         name: name ?? this.name,
         country: country ?? this.country,
         description: description ?? this.description,
-        comments: comments ?? this.comments);
+        comments: comments ?? this.comments,
+        minAge: minAge ?? this.minAge,
+        maxAge: maxAge ?? this.maxAge,
+        requiredSex: requiredSex ?? this.requiredSex);
   }
 
   Map<String, dynamic> toJson() {
@@ -43,7 +57,10 @@ class Survey extends Equatable {
       'name': name,
       'country': country,
       'description': description,
-      'comments': comments
+      'comments': comments,
+      'minAge': minAge,
+      'maxAge': maxAge,
+      'requiredSex': requiredSex
     };
   }
 
@@ -53,11 +70,23 @@ class Survey extends Equatable {
         name: json['name'],
         country: json['country'],
         description: json['description'],
-        comments: json['comments']);
+        comments: json['comments'],
+        minAge: json['minAge'],
+        maxAge: json['maxAge'],
+        requiredSex: json['requiredSex']);
   }
 
   @override
   @ignore
-  List<Object?> get props =>
-      [id, surveyId, name, country, description, comments];
+  List<Object?> get props => [
+        id,
+        surveyId,
+        name,
+        country,
+        description,
+        comments,
+        minAge,
+        maxAge,
+        requiredSex
+      ];
 }

--- a/packages/gibsonify_api/lib/src/models/survey.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.dart
@@ -103,26 +103,4 @@ class Survey extends Equatable {
         requiredSex,
         geoArea
       ];
-
-  List<String> checkParameters({required Respondent respondent}) {
-    // TODO: add household location check
-
-    final errors = <String>[];
-    final respondentAge =
-        DateTime.now().difference(respondent.dateOfBirth!).inDays / 365;
-
-    if (respondentAge < minAge) {
-      errors.add('Respondent is too young.');
-    }
-
-    if (maxAge != 100 && respondentAge > maxAge) {
-      errors.add('Respondent is too old.');
-    }
-
-    if (requiredSex != null && respondent.sex != requiredSex) {
-      errors.add('Respondent must be ${requiredSex!.name}.');
-    }
-
-    return errors;
-  }
 }

--- a/packages/gibsonify_api/lib/src/models/survey.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.dart
@@ -17,6 +17,7 @@ class Survey extends Equatable {
   final int maxAge;
   @Enumerated(EnumType.ordinal32)
   final Sex? requiredSex;
+  final String? geoArea;
 
   Survey(
       {this.id = Isar.autoIncrement,
@@ -27,7 +28,8 @@ class Survey extends Equatable {
       this.comments,
       required this.minAge,
       required this.maxAge,
-      this.requiredSex});
+      this.requiredSex,
+      this.geoArea});
 
   Survey copyWith(
       {Id? id,
@@ -38,7 +40,8 @@ class Survey extends Equatable {
       String? comments,
       int? minAge,
       int? maxAge,
-      Sex? requiredSex}) {
+      Sex? requiredSex,
+      String? geoArea}) {
     return Survey(
         id: id ?? this.id,
         surveyId: surveyId ?? this.surveyId,
@@ -48,7 +51,8 @@ class Survey extends Equatable {
         comments: comments ?? this.comments,
         minAge: minAge ?? this.minAge,
         maxAge: maxAge ?? this.maxAge,
-        requiredSex: requiredSex ?? this.requiredSex);
+        requiredSex: requiredSex ?? this.requiredSex,
+        geoArea: geoArea ?? this.geoArea);
   }
 
   Map<String, dynamic> toJson() {
@@ -60,7 +64,8 @@ class Survey extends Equatable {
       'comments': comments,
       'minAge': minAge,
       'maxAge': maxAge,
-      'requiredSex': requiredSex?.name
+      'requiredSex': requiredSex?.name,
+      'geoArea': geoArea
     };
   }
 
@@ -80,7 +85,8 @@ class Survey extends Equatable {
         comments: json['comments'],
         minAge: json['minAge'],
         maxAge: json['maxAge'],
-        requiredSex: requiredSex);
+        requiredSex: requiredSex,
+        geoArea: json['geoArea']);
   }
 
   @override
@@ -94,7 +100,8 @@ class Survey extends Equatable {
         comments,
         minAge,
         maxAge,
-        requiredSex
+        requiredSex,
+        geoArea
       ];
 
   List<String> checkParameters({required Respondent respondent}) {

--- a/packages/gibsonify_api/lib/src/models/survey.g.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.g.dart
@@ -32,13 +32,29 @@ const SurveySchema = CollectionSchema(
       name: r'description',
       type: IsarType.string,
     ),
-    r'name': PropertySchema(
+    r'maxAge': PropertySchema(
       id: 3,
+      name: r'maxAge',
+      type: IsarType.long,
+    ),
+    r'minAge': PropertySchema(
+      id: 4,
+      name: r'minAge',
+      type: IsarType.long,
+    ),
+    r'name': PropertySchema(
+      id: 5,
       name: r'name',
       type: IsarType.string,
     ),
+    r'requiredSex': PropertySchema(
+      id: 6,
+      name: r'requiredSex',
+      type: IsarType.int,
+      enumMap: _SurveyrequiredSexEnumValueMap,
+    ),
     r'surveyId': PropertySchema(
-      id: 4,
+      id: 7,
       name: r'surveyId',
       type: IsarType.string,
     )
@@ -104,8 +120,11 @@ void _surveySerialize(
   writer.writeString(offsets[0], object.comments);
   writer.writeString(offsets[1], object.country);
   writer.writeString(offsets[2], object.description);
-  writer.writeString(offsets[3], object.name);
-  writer.writeString(offsets[4], object.surveyId);
+  writer.writeLong(offsets[3], object.maxAge);
+  writer.writeLong(offsets[4], object.minAge);
+  writer.writeString(offsets[5], object.name);
+  writer.writeInt(offsets[6], object.requiredSex?.index);
+  writer.writeString(offsets[7], object.surveyId);
 }
 
 Survey _surveyDeserialize(
@@ -119,8 +138,12 @@ Survey _surveyDeserialize(
     country: reader.readString(offsets[1]),
     description: reader.readStringOrNull(offsets[2]),
     id: id,
-    name: reader.readString(offsets[3]),
-    surveyId: reader.readString(offsets[4]),
+    maxAge: reader.readLongOrNull(offsets[3]),
+    minAge: reader.readLongOrNull(offsets[4]),
+    name: reader.readString(offsets[5]),
+    requiredSex:
+        _SurveyrequiredSexValueEnumMap[reader.readIntOrNull(offsets[6])],
+    surveyId: reader.readString(offsets[7]),
   );
   return object;
 }
@@ -139,13 +162,29 @@ P _surveyDeserializeProp<P>(
     case 2:
       return (reader.readStringOrNull(offset)) as P;
     case 3:
-      return (reader.readString(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 4:
+      return (reader.readLongOrNull(offset)) as P;
+    case 5:
+      return (reader.readString(offset)) as P;
+    case 6:
+      return (_SurveyrequiredSexValueEnumMap[reader.readIntOrNull(offset)])
+          as P;
+    case 7:
       return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
   }
 }
+
+const _SurveyrequiredSexEnumValueMap = {
+  'male': 0,
+  'female': 1,
+};
+const _SurveyrequiredSexValueEnumMap = {
+  0: Sex.male,
+  1: Sex.female,
+};
 
 Id _surveyGetId(Survey object) {
   return object.id;
@@ -806,6 +845,144 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'maxAge',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'maxAge',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'maxAge',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'maxAge',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'maxAge',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'maxAge',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'minAge',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'minAge',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'minAge',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'minAge',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'minAge',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'minAge',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Survey, Survey, QAfterFilterCondition> nameEqualTo(
     String value, {
     bool caseSensitive = true,
@@ -931,6 +1108,75 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'name',
         value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> requiredSexIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'requiredSex',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> requiredSexIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'requiredSex',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> requiredSexEqualTo(
+      Sex? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'requiredSex',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> requiredSexGreaterThan(
+    Sex? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'requiredSex',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> requiredSexLessThan(
+    Sex? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'requiredSex',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> requiredSexBetween(
+    Sex? lower,
+    Sex? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'requiredSex',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
       ));
     });
   }
@@ -1107,6 +1353,30 @@ extension SurveyQuerySortBy on QueryBuilder<Survey, Survey, QSortBy> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByMaxAge() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'maxAge', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByMaxAgeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'maxAge', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByMinAge() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'minAge', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByMinAgeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'minAge', Sort.desc);
+    });
+  }
+
   QueryBuilder<Survey, Survey, QAfterSortBy> sortByName() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.asc);
@@ -1116,6 +1386,18 @@ extension SurveyQuerySortBy on QueryBuilder<Survey, Survey, QSortBy> {
   QueryBuilder<Survey, Survey, QAfterSortBy> sortByNameDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByRequiredSex() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'requiredSex', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByRequiredSexDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'requiredSex', Sort.desc);
     });
   }
 
@@ -1181,6 +1463,30 @@ extension SurveyQuerySortThenBy on QueryBuilder<Survey, Survey, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByMaxAge() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'maxAge', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByMaxAgeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'maxAge', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByMinAge() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'minAge', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByMinAgeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'minAge', Sort.desc);
+    });
+  }
+
   QueryBuilder<Survey, Survey, QAfterSortBy> thenByName() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.asc);
@@ -1190,6 +1496,18 @@ extension SurveyQuerySortThenBy on QueryBuilder<Survey, Survey, QSortThenBy> {
   QueryBuilder<Survey, Survey, QAfterSortBy> thenByNameDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByRequiredSex() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'requiredSex', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByRequiredSexDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'requiredSex', Sort.desc);
     });
   }
 
@@ -1228,10 +1546,28 @@ extension SurveyQueryWhereDistinct on QueryBuilder<Survey, Survey, QDistinct> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QDistinct> distinctByMaxAge() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'maxAge');
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QDistinct> distinctByMinAge() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'minAge');
+    });
+  }
+
   QueryBuilder<Survey, Survey, QDistinct> distinctByName(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'name', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QDistinct> distinctByRequiredSex() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'requiredSex');
     });
   }
 
@@ -1268,9 +1604,27 @@ extension SurveyQueryProperty on QueryBuilder<Survey, Survey, QQueryProperty> {
     });
   }
 
+  QueryBuilder<Survey, int?, QQueryOperations> maxAgeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'maxAge');
+    });
+  }
+
+  QueryBuilder<Survey, int?, QQueryOperations> minAgeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'minAge');
+    });
+  }
+
   QueryBuilder<Survey, String, QQueryOperations> nameProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'name');
+    });
+  }
+
+  QueryBuilder<Survey, Sex?, QQueryOperations> requiredSexProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'requiredSex');
     });
   }
 

--- a/packages/gibsonify_api/lib/src/models/survey.g.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.g.dart
@@ -138,8 +138,8 @@ Survey _surveyDeserialize(
     country: reader.readString(offsets[1]),
     description: reader.readStringOrNull(offsets[2]),
     id: id,
-    maxAge: reader.readLongOrNull(offsets[3]),
-    minAge: reader.readLongOrNull(offsets[4]),
+    maxAge: reader.readLong(offsets[3]),
+    minAge: reader.readLong(offsets[4]),
     name: reader.readString(offsets[5]),
     requiredSex:
         _SurveyrequiredSexValueEnumMap[reader.readIntOrNull(offsets[6])],
@@ -162,9 +162,9 @@ P _surveyDeserializeProp<P>(
     case 2:
       return (reader.readStringOrNull(offset)) as P;
     case 3:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 4:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 5:
       return (reader.readString(offset)) as P;
     case 6:
@@ -845,24 +845,7 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
     });
   }
 
-  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeIsNull() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(const FilterCondition.isNull(
-        property: r'maxAge',
-      ));
-    });
-  }
-
-  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeIsNotNull() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(const FilterCondition.isNotNull(
-        property: r'maxAge',
-      ));
-    });
-  }
-
-  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeEqualTo(
-      int? value) {
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeEqualTo(int value) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
         property: r'maxAge',
@@ -872,7 +855,7 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
   }
 
   QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeGreaterThan(
-    int? value, {
+    int value, {
     bool include = false,
   }) {
     return QueryBuilder.apply(this, (query) {
@@ -885,7 +868,7 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
   }
 
   QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeLessThan(
-    int? value, {
+    int value, {
     bool include = false,
   }) {
     return QueryBuilder.apply(this, (query) {
@@ -898,8 +881,8 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
   }
 
   QueryBuilder<Survey, Survey, QAfterFilterCondition> maxAgeBetween(
-    int? lower,
-    int? upper, {
+    int lower,
+    int upper, {
     bool includeLower = true,
     bool includeUpper = true,
   }) {
@@ -914,24 +897,7 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
     });
   }
 
-  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeIsNull() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(const FilterCondition.isNull(
-        property: r'minAge',
-      ));
-    });
-  }
-
-  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeIsNotNull() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(const FilterCondition.isNotNull(
-        property: r'minAge',
-      ));
-    });
-  }
-
-  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeEqualTo(
-      int? value) {
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeEqualTo(int value) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
         property: r'minAge',
@@ -941,7 +907,7 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
   }
 
   QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeGreaterThan(
-    int? value, {
+    int value, {
     bool include = false,
   }) {
     return QueryBuilder.apply(this, (query) {
@@ -954,7 +920,7 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
   }
 
   QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeLessThan(
-    int? value, {
+    int value, {
     bool include = false,
   }) {
     return QueryBuilder.apply(this, (query) {
@@ -967,8 +933,8 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
   }
 
   QueryBuilder<Survey, Survey, QAfterFilterCondition> minAgeBetween(
-    int? lower,
-    int? upper, {
+    int lower,
+    int upper, {
     bool includeLower = true,
     bool includeUpper = true,
   }) {
@@ -1604,13 +1570,13 @@ extension SurveyQueryProperty on QueryBuilder<Survey, Survey, QQueryProperty> {
     });
   }
 
-  QueryBuilder<Survey, int?, QQueryOperations> maxAgeProperty() {
+  QueryBuilder<Survey, int, QQueryOperations> maxAgeProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'maxAge');
     });
   }
 
-  QueryBuilder<Survey, int?, QQueryOperations> minAgeProperty() {
+  QueryBuilder<Survey, int, QQueryOperations> minAgeProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'minAge');
     });

--- a/packages/gibsonify_api/lib/src/models/survey.g.dart
+++ b/packages/gibsonify_api/lib/src/models/survey.g.dart
@@ -32,29 +32,34 @@ const SurveySchema = CollectionSchema(
       name: r'description',
       type: IsarType.string,
     ),
-    r'maxAge': PropertySchema(
+    r'geoArea': PropertySchema(
       id: 3,
+      name: r'geoArea',
+      type: IsarType.string,
+    ),
+    r'maxAge': PropertySchema(
+      id: 4,
       name: r'maxAge',
       type: IsarType.long,
     ),
     r'minAge': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'minAge',
       type: IsarType.long,
     ),
     r'name': PropertySchema(
-      id: 5,
+      id: 6,
       name: r'name',
       type: IsarType.string,
     ),
     r'requiredSex': PropertySchema(
-      id: 6,
+      id: 7,
       name: r'requiredSex',
       type: IsarType.int,
       enumMap: _SurveyrequiredSexEnumValueMap,
     ),
     r'surveyId': PropertySchema(
-      id: 7,
+      id: 8,
       name: r'surveyId',
       type: IsarType.string,
     )
@@ -106,6 +111,12 @@ int _surveyEstimateSize(
       bytesCount += 3 + value.length * 3;
     }
   }
+  {
+    final value = object.geoArea;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
   bytesCount += 3 + object.name.length * 3;
   bytesCount += 3 + object.surveyId.length * 3;
   return bytesCount;
@@ -120,11 +131,12 @@ void _surveySerialize(
   writer.writeString(offsets[0], object.comments);
   writer.writeString(offsets[1], object.country);
   writer.writeString(offsets[2], object.description);
-  writer.writeLong(offsets[3], object.maxAge);
-  writer.writeLong(offsets[4], object.minAge);
-  writer.writeString(offsets[5], object.name);
-  writer.writeInt(offsets[6], object.requiredSex?.index);
-  writer.writeString(offsets[7], object.surveyId);
+  writer.writeString(offsets[3], object.geoArea);
+  writer.writeLong(offsets[4], object.maxAge);
+  writer.writeLong(offsets[5], object.minAge);
+  writer.writeString(offsets[6], object.name);
+  writer.writeInt(offsets[7], object.requiredSex?.index);
+  writer.writeString(offsets[8], object.surveyId);
 }
 
 Survey _surveyDeserialize(
@@ -137,13 +149,14 @@ Survey _surveyDeserialize(
     comments: reader.readStringOrNull(offsets[0]),
     country: reader.readString(offsets[1]),
     description: reader.readStringOrNull(offsets[2]),
+    geoArea: reader.readStringOrNull(offsets[3]),
     id: id,
-    maxAge: reader.readLong(offsets[3]),
-    minAge: reader.readLong(offsets[4]),
-    name: reader.readString(offsets[5]),
+    maxAge: reader.readLong(offsets[4]),
+    minAge: reader.readLong(offsets[5]),
+    name: reader.readString(offsets[6]),
     requiredSex:
-        _SurveyrequiredSexValueEnumMap[reader.readIntOrNull(offsets[6])],
-    surveyId: reader.readString(offsets[7]),
+        _SurveyrequiredSexValueEnumMap[reader.readIntOrNull(offsets[7])],
+    surveyId: reader.readString(offsets[8]),
   );
   return object;
 }
@@ -162,15 +175,17 @@ P _surveyDeserializeProp<P>(
     case 2:
       return (reader.readStringOrNull(offset)) as P;
     case 3:
-      return (reader.readLong(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 4:
       return (reader.readLong(offset)) as P;
     case 5:
-      return (reader.readString(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 6:
+      return (reader.readString(offset)) as P;
+    case 7:
       return (_SurveyrequiredSexValueEnumMap[reader.readIntOrNull(offset)])
           as P;
-    case 7:
+    case 8:
       return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -793,6 +808,152 @@ extension SurveyQueryFilter on QueryBuilder<Survey, Survey, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'geoArea',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'geoArea',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'geoArea',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'geoArea',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'geoArea',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'geoArea',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'geoArea',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'geoArea',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'geoArea',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'geoArea',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'geoArea',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterFilterCondition> geoAreaIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'geoArea',
+        value: '',
+      ));
+    });
+  }
+
   QueryBuilder<Survey, Survey, QAfterFilterCondition> idEqualTo(Id value) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
@@ -1319,6 +1480,18 @@ extension SurveyQuerySortBy on QueryBuilder<Survey, Survey, QSortBy> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByGeoArea() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'geoArea', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> sortByGeoAreaDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'geoArea', Sort.desc);
+    });
+  }
+
   QueryBuilder<Survey, Survey, QAfterSortBy> sortByMaxAge() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'maxAge', Sort.asc);
@@ -1417,6 +1590,18 @@ extension SurveyQuerySortThenBy on QueryBuilder<Survey, Survey, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByGeoArea() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'geoArea', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Survey, Survey, QAfterSortBy> thenByGeoAreaDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'geoArea', Sort.desc);
+    });
+  }
+
   QueryBuilder<Survey, Survey, QAfterSortBy> thenById() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'id', Sort.asc);
@@ -1512,6 +1697,13 @@ extension SurveyQueryWhereDistinct on QueryBuilder<Survey, Survey, QDistinct> {
     });
   }
 
+  QueryBuilder<Survey, Survey, QDistinct> distinctByGeoArea(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'geoArea', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<Survey, Survey, QDistinct> distinctByMaxAge() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'maxAge');
@@ -1567,6 +1759,12 @@ extension SurveyQueryProperty on QueryBuilder<Survey, Survey, QQueryProperty> {
   QueryBuilder<Survey, String?, QQueryOperations> descriptionProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'description');
+    });
+  }
+
+  QueryBuilder<Survey, String?, QQueryOperations> geoAreaProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'geoArea');
     });
   }
 

--- a/packages/gibsonify_api/pubspec.yaml
+++ b/packages/gibsonify_api/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   intl: ^0.17.0
   isar: ^3.0.5
   isar_flutter_libs: ^3.0.5
+  latlong2: ^0.8.1
 
 dev_dependencies:
   build_runner: ^2.3.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -326,6 +326,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_map:
+    dependency: "direct main"
+    description:
+      name: flutter_map
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   flutter_p2p_connection:
     dependency: "direct main"
     description:
@@ -534,6 +541,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.7.0"
+  latlong2:
+    dependency: "direct main"
+    description:
+      name: latlong2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.1"
   lints:
     dependency: transitive
     description:
@@ -541,6 +555,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  lists:
+    dependency: transitive
+    description:
+      name: lists
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -569,6 +590,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  mgrs_dart:
+    dependency: transitive
+    description:
+      name: mgrs_dart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   mime:
     dependency: transitive
     description:
@@ -751,6 +779,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  polylabel:
+    dependency: transitive
+    description:
+      name: polylabel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   pool:
     dependency: transitive
     description:
@@ -758,6 +793,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
+  positioned_tap_detector_2:
+    dependency: transitive
+    description:
+      name: positioned_tap_detector_2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   process:
     dependency: transitive
     description:
@@ -765,6 +807,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.4"
+  proj4dart:
+    dependency: transitive
+    description:
+      name: proj4dart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   provider:
     dependency: transitive
     description:
@@ -1001,6 +1050,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -1008,6 +1064,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1113,6 +1176,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  wkt_parser:
+    dependency: transitive
+    description:
+      name: wkt_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1143,4 +1213,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.18.4 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
+  bezier:
+    dependency: transitive
+    description:
+      name: bezier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   bloc:
     dependency: "direct main"
     description:
@@ -225,6 +232,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.8"
   diff_match_patch:
     dependency: transitive
     description:
@@ -293,6 +307,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_background:
+    dependency: transitive
+    description:
+      name: flutter_background
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   flutter_bloc:
     dependency: "direct main"
     description:
@@ -321,6 +342,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  flutter_local_notifications:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "12.0.4"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.0"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -333,6 +375,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  flutter_map_tile_caching:
+    dependency: "direct main"
+    description:
+      name: flutter_map_tile_caching
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.2.0"
   flutter_p2p_connection:
     dependency: "direct main"
     description:
@@ -485,6 +534,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.2"
+  ini:
+    dependency: transitive
+    description:
+      name: ini
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   intl:
     dependency: "direct main"
     description:
@@ -625,6 +681,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
+  move_to_background:
+    dependency: transitive
+    description:
+      name: move_to_background
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   nested:
     dependency: transitive
     description:
@@ -849,6 +912,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  queue:
+    dependency: transitive
+    description:
+      name: queue
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0+2"
   share_plus:
     dependency: "direct main"
     description:
@@ -1043,6 +1113,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.1"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  country_picker:
+    dependency: "direct main"
+    description:
+      name: country_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.19"
   country_pickers:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   country_picker: ^2.0.19
   flutter_map: ^3.1.0
   latlong2: ^0.8.1
+  flutter_map_tile_caching: ^6.2.0
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
     git:
       url: https://github.com/Archie-C/gibsonify_data_transfer.git
       ref: main
+  country_picker: ^2.0.19
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,8 @@ dependencies:
       url: https://github.com/Archie-C/gibsonify_data_transfer.git
       ref: main
   country_picker: ^2.0.19
+  flutter_map: ^3.1.0
+  latlong2: ^0.8.1
 
 
 dev_dependencies:


### PR DESCRIPTION
Closes #77 

Adds several new features around survey parameters and validation:

- Adds min/max respondent age, respondent sex and geographical area as survey parameters
- Adds geographical area select and view screens with OpenStreetMap and caching
- When starting a collection, it can now only be linked to surveys that are valid for that household location and respondent age/sex.