### PR TITLE
fix(households): crash on delayed position update

### DIFF
--- a/lib/households/bloc/households_bloc.dart
+++ b/lib/households/bloc/households_bloc.dart
@@ -108,7 +108,11 @@ class HouseholdsBloc extends Bloc<HouseholdsEvent, HouseholdsState> {
   void _onLocationUpdateRequested(
       LocationUpdateRequested event, Emitter<HouseholdsState> emit) async {
     final position = await getPosition();
-    add(LocationUpdated(position: position));
+    try {
+      add(LocationUpdated(position: position));
+    } on StateError {
+      // Do nothing
+    }
   }
 
   void _onLocationUpdated(


### PR DESCRIPTION
Fixes a bug where a crash would occur if navigating away from the households page before a location request completes. The code would attempt to add a position update event after the bloc has been disposed.